### PR TITLE
Added partial word matching support for items - on the ground, in inv…

### DIFF
--- a/src/actinf.c
+++ b/src/actinf.c
@@ -650,9 +650,20 @@ P_obj get_object_in_equip_vis(P_char ch, char *arg, int *j)
 P_obj get_object_in_equip(P_char ch, char *arg, int *j)
 {
   for ((*j) = 0; (*j) < MAX_WEAR; (*j)++)
-    if (ch->equipment[(*j)])
-      if (isname(arg, ch->equipment[(*j)]->name))
-        return (ch->equipment[(*j)]);
+	  if (ch->equipment[(*j)])
+	  {
+          if (IS_SET(PLR3_FLAGS(ch), PLR3_PARTIAL_MATCH))
+          {
+              if (isname_partial(arg, ch->equipment[(*j)]->name))
+                  return (ch->equipment[(*j)]);
+          }
+          else
+          {
+              if (isname(arg, ch->equipment[(*j)]->name))
+                  return (ch->equipment[(*j)]);
+		  }
+	  }
+      
 
   return (0);
 }

--- a/src/actobj.c
+++ b/src/actobj.c
@@ -496,8 +496,21 @@ void do_get(P_char ch, char *argument, int cmd)
     {
       next_obj = o_obj->next_content;
 
-      if (alldot && !isname(Gbuf2, o_obj->name))
-        continue;
+	  if (alldot) 
+      {
+		  if (IS_SET(PLR3_FLAGS(ch), PLR3_PARTIAL_MATCH))
+          {
+			  /* partial match mode */
+			  if (!isname_partial(Gbuf2, o_obj->name))
+				  continue;
+		  }
+		  else 
+          {
+			  /* strict match mode */
+			  if (!isname(Gbuf2, o_obj->name))
+				  continue;
+		  }
+	  }
 
       if (CAN_SEE_OBJ(ch, o_obj))
       {
@@ -729,8 +742,21 @@ void do_get(P_char ch, char *argument, int cmd)
         {
           next_obj = o_obj->next_content;
 
-          if (alldot && !isname(Gbuf2, o_obj->name))
-            continue;
+		  if (alldot) 
+          {
+			  if IS_SET(PLR3_FLAGS(ch), PLR3_PARTIAL_MATCH)
+              {
+				  /* partial match mode */
+				  if (!isname_partial(Gbuf2, o_obj->name))
+					  continue;
+			  }
+			  else 
+              {
+				  /* strict match mode */
+				  if (!isname(Gbuf2, o_obj->name))
+					  continue;
+			  }
+		  }
 
           /*
            * fixed an annoying bug, you can now always get

--- a/src/actoth.c
+++ b/src/actoth.c
@@ -4276,98 +4276,100 @@ void show_toggles(P_char ch)
   }
 
   snprintf(Gbuf1, MAX_STRING_LENGTH,
-          "&+y-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
-          "-=-=-=-=-=-=-=-=-=-=-=-=-=-&N\r\n"
-          "                          &+r    STATUS of toggles.    "
-          "                           &N\r\n"
-          "&+y-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
-          "-=-=-=-=-=-=-=-=-=-=-=-=-=-&N\r\n"
-          "&+r   Tell        :&+g %-3s    &+y|&N"
-          "&+r     Brief Mode  :&+g %-3s    &+y|&N"
-          "&+r     No Locate   :&+g %-3s    &+y|&N\r\n"
-          "&+r   SmartPrompt :&+g %-3s    &+y|&N"
-          "&+r     Compact Mode:&+g %-3s    &+y|&N"
-          "&+r     Wimpy Level :&+g %-4s   &+y|&N\r\n"
-          "&+r   Shout       :&+g %-3s    &+y|&N"
-          "&+r     Echo        :&+g %-3s    &+y|&N"
-          "&+r     Vicious     :&+g %-3s    &+y|&N\r\n"
-          "&+r   Petition    :&+g %-3s    &+y|&N"
-          "&+r     Paging      :&+g %-3s    &+y|&N"
-          "&+r     Save Notify :&+g %-3s    &+y|&N\r\n"
-          "&+r   Who List    :&+g %-3s    &+y|&N"
-          "&+r     Screen Size :&+g %-3s    &+y|&N"
-          "&+r     Terminal    :&+g %-4s   &+y|&N\r\n"
-          "&+r   Map         :&+g %-3s    &+y|&N"
-          "&+r     Old SmartP  :&+g %-3s    &+y|&N"
-          "&+r     Show Titles :&+g %-3s    &+y|&N\r\n"
-          "&+r   Battle Alert:&+g %-3s    &+y|&N"
-          "&+r     Kingdom View:&+g %-3s    &+y|&N"
-          "&+r     Ship Map    :&+g %-3s    &+y|&N\r\n"
-          "&+r   Take        :&+g %-3s    &+y|&N"
-          "&+r     Terse Battle:&+g %-3s    &+y|&N"
-          "&+r     QuickChant  :&+g %-3s    &+y|&N\r\n"
-          "&+r   Project     :&+g %-3s    &+y|&N"
-          "&+r     AFK         :&+g %-3s    &+y|&N"
-          "&+r     NChat       :&+g %-3s    &+y|&N\r\n"
-          "&+r   Hint Channel:&+g %-3s    &+y|&N"
-          "&+r     Group Needed:&+g %-3s    &+y|&N"
-          "&+r     Showspec    :&+g %-3s    &+y|&N\r\n"
-          "&+r   Web Info    :&+g %-3s    &+y|&N"
-          "&+r     Show Quests :&+g %-3s    &+y|&N"
-          "&+r     Boons       :&+g %-3s    &+y|&N\r\n"
-          "&+r   Newbie EQ   :&+g %-3s    &+y|&N"
-          "&+r     No Beep     :&+g %-3s    &+y|&n"
-          "&+r     Underline   :&+g %-3s    &+y|&N\r\n"
-          "&+r   Surname     :&+g %-3s    &+y|"
-          "&+r     Damage      :&+g %-3s    &+y|&n"
-          "&+r     No Level    :&+g %-3s    &+y|&n\r\n"
-          "&+r   PetDamage   :&+g %-3s    &+y|"
-          "&+r     Guildname   :&+g %-3s    &+y|"
-          "&+r     GMCP        :&+g %-3s    &+y|&n\r\n"
-          "&+y-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
-          "-=-=-=-=-=-=-=-=-=-=-=-=-=-&N\r\n",
-          ONOFF(!PLR_FLAGGED(ch, PLR_NOTELL)),
-          ONOFF(PLR_FLAGGED(ch, PLR_BRIEF)),
-          ONOFF(PLR2_FLAGGED(ch, PLR2_NOLOCATE)),
-          ONOFF(PLR_FLAGGED(ch, PLR_SMARTPROMPT)),
-          ONOFF(PLR_FLAGGED(ch, PLR_COMPACT)),
-          Gbuf2,
-          ONOFF(!PLR_FLAGGED(ch, PLR_NOSHOUT)),
-          ONOFF(PLR_FLAGGED(ch, PLR_ECHO)),
-          ONOFF(PLR_FLAGGED(ch, PLR_VICIOUS)),
-          ONOFF(PLR_FLAGGED(ch, PLR_PETITION)),
-          ONOFF(PLR_FLAGGED(ch, PLR_PAGING_ON)),
-          ONOFF(PLR_FLAGGED(ch, PLR_SNOTIFY)),
-          ONOFF(PLR_FLAGGED(ch, PLR_NOWHO)),
-          Gbuf3,
-          (send_ch->desc->term_type == 1 ? "GEN " : (send_ch->desc->term_type == 2 ? "ANSI" : "MSP ")),
-          ONOFF(PLR_FLAGGED(ch, PLR_MAP)),
-          ONOFF(PLR_FLAGGED(ch, PLR_OLDSMARTP)),
-          ONOFF(!PLR2_FLAGGED(ch, PLR2_NOTITLE)),
-          ONOFF(PLR2_FLAGGED(ch, PLR2_BATTLEALERT)),
-          ONOFF(PLR2_FLAGGED(ch, PLR2_KINGDOMVIEW)),
-          ONOFF(PLR2_FLAGGED(ch, PLR2_SHIPMAP)),
-          ONOFF(!PLR2_FLAGGED(ch, PLR2_NOTAKE)),
-          ONOFF(PLR2_FLAGGED(ch, PLR2_TERSE)),
-          ONOFF(PLR2_FLAGGED(ch, PLR2_QUICKCHANT)),
-          ONOFF(PLR2_FLAGGED(ch, PLR2_PROJECT)),
-          ONOFF(PLR_FLAGGED(ch, PLR_AFK)),
-          ONOFF(PLR2_FLAGGED(ch, PLR2_NCHAT)),
-          ONOFF(PLR2_FLAGGED(ch, PLR2_HINT_CHANNEL)),
-          ONOFF(PLR2_FLAGGED(ch, PLR2_LGROUP)),
-          ONOFF(PLR2_FLAGGED(ch, PLR2_SPEC)),
-          ONOFF(PLR2_FLAGGED(ch, PLR2_WEBINFO)),
-          ONOFF(PLR2_FLAGGED(ch, PLR2_SHOW_QUEST)),
-          ONOFF(PLR2_FLAGGED(ch, PLR2_BOON)),
-          ONOFF(PLR2_FLAGGED(ch, PLR2_NEWBIEEQ)),
-          ONOFF(PLR3_FLAGGED(ch, PLR3_NOBEEP)),
-          ONOFF(PLR3_FLAGGED(ch, PLR3_UNDERLINE)),
-          ONOFF(PLR3_FLAGGED(ch, PLR3_SURNAMES)),
-          ONOFF(PLR2_FLAGGED(ch, PLR2_DAMAGE)),
-          ONOFF(PLR3_FLAGGED(ch, PLR3_NOLEVEL)),
-          ONOFF(PLR3_FLAGGED(ch, PLR3_PET_DAMAGE)),
-          ONOFF(PLR3_FLAGGED(ch, PLR3_GUILDNAME)),
-          ONOFF(!PLR3_FLAGGED(ch, PLR3_NOGMCP)) );
+      "&+y-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+      "-=-=-=-=-=-=-=-=-=-=-=-=-=-&N\r\n"
+      "                          &+r    STATUS of toggles.    "
+      "                           &N\r\n"
+      "&+y-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+      "-=-=-=-=-=-=-=-=-=-=-=-=-=-&N\r\n"
+      "&+r   Tell        :&+g %-3s    &+y|&N"
+      "&+r     Brief Mode  :&+g %-3s    &+y|&N"
+      "&+r     No Locate   :&+g %-3s    &+y|&N\r\n"
+      "&+r   SmartPrompt :&+g %-3s    &+y|&N"
+      "&+r     Compact Mode:&+g %-3s    &+y|&N"
+      "&+r     Wimpy Level :&+g %-4s   &+y|&N\r\n"
+      "&+r   Shout       :&+g %-3s    &+y|&N"
+      "&+r     Echo        :&+g %-3s    &+y|&N"
+      "&+r     Vicious     :&+g %-3s    &+y|&N\r\n"
+      "&+r   Petition    :&+g %-3s    &+y|&N"
+      "&+r     Paging      :&+g %-3s    &+y|&N"
+      "&+r     Save Notify :&+g %-3s    &+y|&N\r\n"
+      "&+r   Who List    :&+g %-3s    &+y|&N"
+      "&+r     Screen Size :&+g %-3s    &+y|&N"
+      "&+r     Terminal    :&+g %-4s   &+y|&N\r\n"
+      "&+r   Map         :&+g %-3s    &+y|&N"
+      "&+r     Old SmartP  :&+g %-3s    &+y|&N"
+      "&+r     Show Titles :&+g %-3s    &+y|&N\r\n"
+      "&+r   Battle Alert:&+g %-3s    &+y|&N"
+      "&+r     Kingdom View:&+g %-3s    &+y|&N"
+      "&+r     Ship Map    :&+g %-3s    &+y|&N\r\n"
+      "&+r   Take        :&+g %-3s    &+y|&N"
+      "&+r     Terse Battle:&+g %-3s    &+y|&N"
+      "&+r     QuickChant  :&+g %-3s    &+y|&N\r\n"
+      "&+r   Project     :&+g %-3s    &+y|&N"
+      "&+r     AFK         :&+g %-3s    &+y|&N"
+      "&+r     NChat       :&+g %-3s    &+y|&N\r\n"
+      "&+r   Hint Channel:&+g %-3s    &+y|&N"
+      "&+r     Group Needed:&+g %-3s    &+y|&N"
+      "&+r     Showspec    :&+g %-3s    &+y|&N\r\n"
+      "&+r   Web Info    :&+g %-3s    &+y|&N"
+      "&+r     Show Quests :&+g %-3s    &+y|&N"
+      "&+r     Boons       :&+g %-3s    &+y|&N\r\n"
+      "&+r   Newbie EQ   :&+g %-3s    &+y|&N"
+      "&+r     No Beep     :&+g %-3s    &+y|&n"
+      "&+r     Underline   :&+g %-3s    &+y|&N\r\n"
+      "&+r   Surname     :&+g %-3s    &+y|"
+      "&+r     Damage      :&+g %-3s    &+y|&n"
+      "&+r     No Level    :&+g %-3s    &+y|&n\r\n"
+      "&+r   PetDamage   :&+g %-3s    &+y|"
+      "&+r     Guildname   :&+g %-3s    &+y|"
+      "&+r     GMCP        :&+g %-3s    &+y|&n\r\n"
+      "&+r   PartialMatch:&+g %-3s    &+y|&n\r\n"
+      "&+y-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+      "-=-=-=-=-=-=-=-=-=-=-=-=-=-&N\r\n",
+      ONOFF(!PLR_FLAGGED(ch, PLR_NOTELL)),
+      ONOFF(PLR_FLAGGED(ch, PLR_BRIEF)),
+      ONOFF(PLR2_FLAGGED(ch, PLR2_NOLOCATE)),
+      ONOFF(PLR_FLAGGED(ch, PLR_SMARTPROMPT)),
+      ONOFF(PLR_FLAGGED(ch, PLR_COMPACT)),
+      Gbuf2,
+      ONOFF(!PLR_FLAGGED(ch, PLR_NOSHOUT)),
+      ONOFF(PLR_FLAGGED(ch, PLR_ECHO)),
+      ONOFF(PLR_FLAGGED(ch, PLR_VICIOUS)),
+      ONOFF(PLR_FLAGGED(ch, PLR_PETITION)),
+      ONOFF(PLR_FLAGGED(ch, PLR_PAGING_ON)),
+      ONOFF(PLR_FLAGGED(ch, PLR_SNOTIFY)),
+      ONOFF(PLR_FLAGGED(ch, PLR_NOWHO)),
+      Gbuf3,
+      (send_ch->desc->term_type == 1 ? "GEN " : (send_ch->desc->term_type == 2 ? "ANSI" : "MSP ")),
+      ONOFF(PLR_FLAGGED(ch, PLR_MAP)),
+      ONOFF(PLR_FLAGGED(ch, PLR_OLDSMARTP)),
+      ONOFF(!PLR2_FLAGGED(ch, PLR2_NOTITLE)),
+      ONOFF(PLR2_FLAGGED(ch, PLR2_BATTLEALERT)),
+      ONOFF(PLR2_FLAGGED(ch, PLR2_KINGDOMVIEW)),
+      ONOFF(PLR2_FLAGGED(ch, PLR2_SHIPMAP)),
+      ONOFF(!PLR2_FLAGGED(ch, PLR2_NOTAKE)),
+      ONOFF(PLR2_FLAGGED(ch, PLR2_TERSE)),
+      ONOFF(PLR2_FLAGGED(ch, PLR2_QUICKCHANT)),
+      ONOFF(PLR2_FLAGGED(ch, PLR2_PROJECT)),
+      ONOFF(PLR_FLAGGED(ch, PLR_AFK)),
+      ONOFF(PLR2_FLAGGED(ch, PLR2_NCHAT)),
+      ONOFF(PLR2_FLAGGED(ch, PLR2_HINT_CHANNEL)),
+      ONOFF(PLR2_FLAGGED(ch, PLR2_LGROUP)),
+      ONOFF(PLR2_FLAGGED(ch, PLR2_SPEC)),
+      ONOFF(PLR2_FLAGGED(ch, PLR2_WEBINFO)),
+      ONOFF(PLR2_FLAGGED(ch, PLR2_SHOW_QUEST)),
+      ONOFF(PLR2_FLAGGED(ch, PLR2_BOON)),
+      ONOFF(PLR2_FLAGGED(ch, PLR2_NEWBIEEQ)),
+      ONOFF(PLR3_FLAGGED(ch, PLR3_NOBEEP)),
+      ONOFF(PLR3_FLAGGED(ch, PLR3_UNDERLINE)),
+      ONOFF(PLR3_FLAGGED(ch, PLR3_SURNAMES)),
+      ONOFF(PLR2_FLAGGED(ch, PLR2_DAMAGE)),
+      ONOFF(PLR3_FLAGGED(ch, PLR3_NOLEVEL)),
+      ONOFF(PLR3_FLAGGED(ch, PLR3_PET_DAMAGE)),
+      ONOFF(PLR3_FLAGGED(ch, PLR3_GUILDNAME)),
+      ONOFF(!PLR3_FLAGGED(ch, PLR3_NOGMCP)),
+      ONOFF(PLR3_FLAGGED(ch, PLR3_PARTIAL_MATCH))  );
   send_to_char(Gbuf1, send_ch);
 
   if (GET_LEVEL(ch) >= AVATAR)
@@ -4398,8 +4400,8 @@ void show_toggles(P_char ch)
             ONOFF(PLR_FLAGGED(ch, PLR_DEBUG)),
             ONOFF(PLR_FLAGGED(ch, PLR_MORTAL)),
             ONOFF(PLR2_FLAGGED(ch, PLR2_HEAL)),
-            ONOFF(PLR3_FLAGGED(ch, PLR3_EPICWATCH)));
-    send_to_char(Gbuf1, send_ch);
+            ONOFF(PLR3_FLAGGED(ch, PLR3_EPICWATCH)) );
+            send_to_char(Gbuf1, send_ch);
     send_to_char("&+y-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-&N\r\n", send_ch);
   }
 }
@@ -4471,6 +4473,7 @@ static const char *toggles_list[] = {
   "petdamage",
   "guildname",
   "gmcp",                 // 65
+  "partialmatch",         // 66  
   "\n"
 };
 
@@ -4597,7 +4600,10 @@ static const char *tog_messages[][2] = {
   {"You turn off the display of your guild name.\r\n",
    "You turn on the display of your guild name.\r\n"},
   {"&+WGMCP&N data streaming enabled.\r\n",
-   "&+WGMCP&N data streaming disabled.\r\n"}
+   "&+WGMCP&N data streaming disabled.\r\n"},
+  { "Partial word matching DISABLED.\r\n",
+	"Partial word matching ENABLED.\r\n" }
+
 };
 
 void do_more(P_char ch, char *arg, int cmd)
@@ -5111,6 +5117,9 @@ void do_toggle(P_char ch, char *arg, int cmd)
   case 65:  /* gmcp */
     result = PLR3_TOG_CHK(ch, PLR3_NOGMCP);
     break;
+  case 66:  /* partialmatch */
+	  result = PLR3_TOG_CHK(ch, PLR3_PARTIAL_MATCH);
+	  break;
   default:
     break;
   }

--- a/src/handler.c
+++ b/src/handler.c
@@ -77,6 +77,7 @@ int map_view_distance(P_char ch, int room);
 bool leave_safe_room( P_char ch );
 void add_weight( P_obj obj, int weight );
 
+
 /*
  * called every 20 seconds, just loops through chars doing...stuff
  */
@@ -741,6 +742,38 @@ bool isname( const char *match, const char *namelist )
         return TRUE;
 }
 */
+
+// modified isname() to allow partial matching - Voodoo
+// isolated so use can be controlled 
+// managed by toggle PRTLMTCH wherever CHAR_DATA is available to check
+int isname_partial(const char* str, const char* namelist)
+{
+   // fprintf(stderr, "++ in PARTIAL MATCH CODE\r\n");
+	char name[MAX_INPUT_LENGTH];
+	const char* p = namelist;
+
+	if (!str || !*str || !namelist || !*namelist)
+		return 0;
+
+	while (*p) {
+		int len = 0;
+
+		/* extract next word from namelist */
+		while (*p && !isspace(*p) && len < MAX_INPUT_LENGTH - 1)
+			name[len++] = *(p++);
+		name[len] = '\0';
+
+		/* prefix match: compare only strlen(str) characters */
+		if (!strncasecmp(str, name, strlen(str)))
+			return 1;
+
+		/* skip spaces */
+		while (isspace(*p))
+			p++;
+	}
+
+	return 0;
+}
 
 
 bool isname(const char *str, const char *namelist)
@@ -1793,7 +1826,8 @@ P_obj get_obj_in_list(char *name, P_obj list)
     return (0);
 
   for (i = list, j = 1; i && (j <= k); i = i->next_content)
-    if (isname(tmp, i->name))
+	  // can do control partial name matches here, no CH to check toggle - Voodoo
+    if (isname_partial(tmp, i->name))
     {
       if (j == k)
         return (i);
@@ -3349,35 +3383,71 @@ P_obj get_obj_in_list_vis(P_char ch, char *name, P_obj list, bool no_tracks )
   }
   if( no_tracks )
   {
-    for (i = list, j = 1; i && (j <= k); i = i->next_content)
-    {
-      if( isname(tmp, i->name)
-        || (IS_PC(ch) && IS_TRUSTED(ch) && atoi(name) > 0 && atoi(name) == OBJ_VNUM(i)) )
+      for (i = list, j = 1; i && (j <= k); i = i->next_content)
       {
-        if( CAN_SEE_OBJ(ch, i) || IS_NOSHOW(i) && OBJ_VNUM(i) != VNUM_TRACKS )
-        {
-          if (j == k)
-            return (i);
-          j++;
-        }
+          if (IS_SET(PLR3_FLAGS(ch), PLR3_PARTIAL_MATCH))
+          {
+              /* partial match mode */
+              if (isname_partial(tmp, i->name)
+                  || (IS_PC(ch) && IS_TRUSTED(ch) && atoi(name) > 0 && atoi(name) == OBJ_VNUM(i)))
+              {
+                  if (CAN_SEE_OBJ(ch, i) || (IS_NOSHOW(i) && OBJ_VNUM(i) != VNUM_TRACKS))
+                  {
+                      if (j == k)
+                          return i;
+                      j++;
+                  }
+              }
+          }
+          else
+          {
+              /* strict match mode */
+              if (isname(tmp, i->name)
+                  || (IS_PC(ch) && IS_TRUSTED(ch) && atoi(name) > 0 && atoi(name) == OBJ_VNUM(i)))
+              {
+                  if (CAN_SEE_OBJ(ch, i) || (IS_NOSHOW(i) && OBJ_VNUM(i) != VNUM_TRACKS))
+                  {
+                      if (j == k)
+                          return i;
+                      j++;
+                  }
+              }
+          }
       }
-    }
   }
   else
   {
-    for (i = list, j = 1; i && (j <= k); i = i->next_content)
-    {
-      if( isname(tmp, i->name)
-        || (IS_PC(ch) && IS_TRUSTED(ch) && atoi(name) > 0 && atoi(name) == OBJ_VNUM(i)) )
-      {
-        if (CAN_SEE_OBJ(ch, i) || IS_NOSHOW(i))
-        {
-          if (j == k)
-            return (i);
-          j++;
-        }
-      }
-    }
+	  for (i = list, j = 1; i && (j <= k); i = i->next_content)
+	  {
+		  if (IS_SET(PLR3_FLAGS(ch), PLR3_PARTIAL_MATCH))
+		  {
+			  /* partial match mode */
+			  if (isname_partial(tmp, i->name)
+				  || (IS_PC(ch) && IS_TRUSTED(ch) && atoi(name) > 0 && atoi(name) == OBJ_VNUM(i)))
+			  {
+				  if (CAN_SEE_OBJ(ch, i) || IS_NOSHOW(i))
+				  {
+					  if (j == k)
+						  return i;
+					  j++;
+				  }
+			  }
+		  }
+		  else
+		  {
+			  /* strict match mode */
+			  if (isname(tmp, i->name)
+				  || (IS_PC(ch) && IS_TRUSTED(ch) && atoi(name) > 0 && atoi(name) == OBJ_VNUM(i)))
+			  {
+				  if (CAN_SEE_OBJ(ch, i) || IS_NOSHOW(i))
+				  {
+					  if (j == k)
+						  return i;
+					  j++;
+				  }
+			  }
+		  }
+	  }
   }
   return (0);
 }
@@ -3924,12 +3994,30 @@ int generic_find(char *arg, int bitvector, P_char ch, P_char * tar_ch, P_obj * t
   }
   if (IS_SET(bitvector, FIND_OBJ_EQUIP))
   {
-    for (found = FALSE, i = 0; i < MAX_WEAR && !found; i++)
-      if (ch->equipment[i] && isname(name, ch->equipment[i]->name))
-      {
-        *tar_obj = ch->equipment[i];
-        found = TRUE;
-      }
+	  for (found = FALSE, i = 0; i < MAX_WEAR && !found; i++)
+	  {
+		  if (!ch->equipment[i])
+			  continue;
+
+		  if (PLR3_FLAGGED(ch, PLR3_PARTIAL_MATCH))
+		  {
+			  /* partial match mode */
+			  if (isname_partial(name, ch->equipment[i]->name))
+			  {
+				  *tar_obj = ch->equipment[i];
+				  found = TRUE;
+			  }
+		  }
+		  else
+		  {
+			  /* strict match mode */
+			  if (isname(name, ch->equipment[i]->name))
+			  {
+				  *tar_obj = ch->equipment[i];
+				  found = TRUE;
+			  }
+		  }
+	  }
     if (found)
     {
       return (FIND_OBJ_EQUIP);

--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -1183,6 +1183,7 @@ int affected_by_spell_count(P_char, int);
 bool affected_by_spell_flagged(P_char, int, uint);
 bool affected_by_skill(P_char ch, int skill);
 bool isname(const char *, const char *);
+int isname_partial(const char* str, const char* namelist);
 char *FirstWord(char *);
 int can_char_use_item(P_char, P_obj);
 int char_light(P_char);

--- a/src/structs.h
+++ b/src/structs.h
@@ -1003,6 +1003,7 @@ struct room_data {
 #define PLR3_EPICWATCH     BIT_20 /* For Immortals: displays calls to epiclog */
 #define PLR3_PET_DAMAGE    BIT_21
 #define PLR3_NOGMCP        BIT_22  /* Player has disabled GMCP */
+#define PLR3_PARTIAL_MATCH BIT_23  /* Player wants partial item name matching */
 
 /* For players : Prompt flags (16 bits max) */
 #define PROMPT_NONE        BIT_1


### PR DESCRIPTION
Added partial word matching support for items - on the ground, in inventory, equipped and in containers. Wrapped everything I could in a toggle (PLR3_PARTIAL_MATCH) which is OFF by default. Added new toggle to show_toggles()

NOTE: get_obj_in_list() now uses isname_partial() by default due to CHAR_DATA not being avaiable to check the toggle.

Intention behind this change - improve usability and reduce tediousness of equipment management.