### PR TITLE
overhaul the input code and ttype negotations

### DIFF
--- a/src/comm.c
+++ b/src/comm.c
@@ -2275,6 +2275,7 @@ int new_descriptor(int s, int conn_type)
 
 static void greet(P_desc newd)
 {
+	check_cp437(newd);
 	if (bannedsite(newd->host, 0))
 	{
 		write_to_descriptor(newd,

--- a/src/comm.c
+++ b/src/comm.c
@@ -64,6 +64,7 @@
 #include "timers.h"
 #include "tradeskill.h"
 #include "ttype.h"
+#include "unicode.h"
 #include "websocket.h"
 #include "world_quest.h"
 #include "ws_handlers.h"
@@ -102,6 +103,7 @@ void              format_to_snoopers(char *from_string, char *to_string);
 extern void       update_breath_weapon_properties();
 extern void       update_regen_properties();
 static void       greet(P_desc newd);
+static void       process_line(P_desc t, char *in);
 
 /* local globals */
 
@@ -2812,9 +2814,8 @@ int process_output(P_desc t)
 
 int process_input(P_desc t)
 {
-	int            sofar, thisround, begin, squelch, i, k, flag;
-	char           tmp[MAX_INPUT_LENGTH + 3], buffer[MAX_INPUT_LENGTH + 60];
-	snoop_by_data *snoop_by_ptr;
+	int            thisround, begin;
+	char           tmp[MAX_INPUT_LENGTH + 3], *buf, *bp;
 
 	/* WebSocket connections use their own input processing */
 	if (t->websocket)
@@ -2822,213 +2823,157 @@ int process_input(P_desc t)
 		return websocket_process_input(t);
 	}
 
-	sofar = 0;
-	flag  = 0;
-	begin = strlen(t->buf);
+	begin = t->buflen;
+	if (begin < 0 || begin >= MAX_QUEUE_LENGTH)
+		abort(); // likely memory corruption
+	buf = t->buf;
 
 	/*
 	 * Read in some stuff
 	 */
 	if (t->sslses)
 	{
-		thisround = gnutls_record_recv(t->sslses, t->buf + begin, (MAX_QUEUE_LENGTH - begin));
+		thisround = gnutls_record_recv(t->sslses, buf + begin, MAX_QUEUE_LENGTH - begin - 1);
 		if (!thisround)
 		{
 			logit(LOG_COMM, "EOF encountered on socket read for %s.", (t->character) ? GET_NAME(t->character) : "NOCHAR");
 			return (-1);
 		}
-		else if (thisround > 0)
-			sofar += thisround;
-		else if (thisround != GNUTLS_E_AGAIN && thisround != GNUTLS_E_INTERRUPTED)
+		else if (thisround < 0)
 		{
-			logit(LOG_COMM, "process_input() CON_%d %s Read: %d Error: %s", t->connected, (t->character) ? GET_NAME(t->character) : "", thisround, gnutls_strerror(thisround));
-			return (-1);
+			if (thisround != GNUTLS_E_AGAIN && thisround != GNUTLS_E_INTERRUPTED)
+			{
+				logit(LOG_COMM, "process_input() CON_%d %s Read: %d Error: %s", t->connected, (t->character) ? GET_NAME(t->character) : "", thisround, gnutls_strerror(thisround));
+				return (-1);
+			}
+			return 0;
 		}
 	}
 	else
-		do
+	{
+		thisround = read(t->descriptor, buf + begin, MAX_QUEUE_LENGTH - begin - 1);
+		if (!thisround)
 		{
-			if ((thisround = read(t->descriptor, (t->buf + begin + sofar), (unsigned)(MAX_QUEUE_LENGTH - begin - sofar - 1))) > 0)
-				sofar += thisround;
-			else if (thisround < 0)
-				if (errno !=
-#ifdef _HPUX_SOURCE
-				    EAGAIN
-#else
-				    EWOULDBLOCK
-#endif
-				)
-				{
-					logit(LOG_COMM, "process_input() CON_%d %s Read: %d Error: %d", t->connected, (t->character) ? GET_NAME(t->character) : "", thisround, errno);
-					return (-1);
-				}
-				else
-					break;
-			else
+			logit(LOG_COMM, "EOF encountered on socket read.");
+			return (-1);
+		}
+		else if (thisround < 0)
+		{
+			if (errno != EAGAIN)
 			{
-				logit(LOG_COMM, "EOF encountered on socket read.");
+				logit(LOG_COMM, "process_input() CON_%d %s Read: %d Error: %d", t->connected, (t->character) ? GET_NAME(t->character) : "", thisround, errno);
 				return (-1);
 			}
-		}
-
-		while (!ISNEWL(*(t->buf + begin + sofar - 1)));
-
-	*(t->buf + begin + sofar) = 0;
-
-	/* processed before user input - no newline */
-	for (i = begin; *(t->buf + i); i++)
-	{
-		if (t->buf[i] == (char)IAC)
-		{
-			int remaining = strlen(t->buf + i);
-			int consumed  = parse_telnet_options(t, t->buf + i, remaining);
-			if (consumed > 0 && consumed <= remaining)
-			{
-				/* remove processed telnet data from buffer */
-				memmove(t->buf + i, t->buf + i + consumed, remaining - consumed + 1);
-				i--; /* recheck this position */
-			}
+			return 0;
 		}
 	}
 
-	/*
-	 * scan input stream for a newline, if one isn't found, command is not
-	 * yet ready for processing, so do not xfer it to input queue, and
-	 * return 0, so that this socket is skipped.
-	 */
+	int len = begin + thisround;
+	buf[len] = 0; // safety vs broken code
+	bp = buf;
 
-	for (i = begin; !ISNEWL(*(t->buf + i)); i++)
-		if (!*(t->buf + i))
-			return (0);
+	for (int i = 0; i < len; i++)
+	{
+		switch (buf[i])
+		{
+		case 0:     // illegal; ignore
+		case '\r':
+			break;
 
+		case '\n':
+			*bp = 0;
+			process_line(t, buf);
+			bp = buf;
+			break;
+
+		case (char)IAC:
+		{
+			int consumed = parse_telnet_options(t, buf + i, len - i);
+			if (consumed <= 0)
+				goto incomplete; // partial; need to wait for more
+			i += consumed - 1;
+		}
+
+		case '\b':
+		case 127: // handle both ^H and DEL
+			while (bp > buf)
+			{
+				// Eat whole Unicode characters, do no other
+				// processing.  We don't support clusters thus
+				// no need to consume multiple codepoints.
+				if (!IS_UTF8_TAIL(*--bp) || t->cp437)
+					break;
+			}
+			break;
+
+		default:
+			*bp++ = buf[i]; // possibly no-op if bp hasn't changed
+		}
+	}
+
+incomplete:
+	if (bp - buf > MAX_INPUT_LENGTH - 1)
+	{
+		// is it even a good idea to process it anyway?
+		*bp = 0;
+		process_line(t, buf);
+		bp = buf;
+	}
+	t->buflen = bp - buf;
+	return 0;
+}
+
+static void process_line(P_desc t, char *in)
+{
+	char out[MAX_QUEUE_LENGTH * 3]; // max expansion
+	char buffer[MAX_STRING_LENGTH];
 #ifdef SMART_PROMPT
 	if (t->character && IS_SET(t->character->specials.act, PLR_SMARTPROMPT))
 		t->prompt_mode = TRUE;
 #endif
 
-	/*
-	 * input contains 1 or more newlines; process the stuff
-	 */
+	if (t->cp437)
+		upgrade_cp437_and_dollars(out, in);
+	else if (validate_utf8_and_dollars(out, in))
+		write_to_descriptor(t, "Bad characters in input, skipped.\r\n");
 
-	for (i = 0, k = 0; *(t->buf + i);)
+	int k = strlen(out);
+	if (k > (MAX_INPUT_LENGTH - 1))
 	{
-		if (!ISNEWL(*(t->buf + i)) && !(flag = (k >= (MAX_INPUT_LENGTH - 2))))
-		{
-			/* telnet */
-			if (t->buf[i] == (char)IAC)
-			{
-				int remaining = strlen(t->buf + i);
-				int consumed  = parse_telnet_options(t, t->buf + i, remaining);
-				if (consumed > 0 && consumed <= remaining)
-					i += consumed;
-				else
-					i++;
-			}
-			/* backspace? (handle both ^H and DEL) */
-			else if (t->buf[i] == '\b' || t->buf[i] == 127)
-			{
-				/* more than one char ? */
-				if (k)
-				{
-					if (*(tmp + --k) == '$')
-						k--;
-					i++;
-				}
-				else
-				{
-					/* no chars to delete, so just skip the backspace */
-					i++;
-				}
-			}
-			else
-			{
-				if (*(t->buf + i) == '$')
-				{
-					/*
-					 * a '$'?  if so, have to double it, so that act()
-					 * won't choke on it later on.
-					 */
-					*(tmp + k) = '$';
-					k++;
-				}
-				/* printable character? */
-				if (isascii(*(t->buf + i)) && isprint(*(t->buf + i)))
-				{
-					*(tmp + k) = *(t->buf + i);
-					i++;
-					k++;
-				}
-				else
-				{
-					/* garbage character, skip it */
-					i++;
-				}
-			}
-		}
-		else
-		{
-			/* newline or input too long, have to actually DO something with it. */
-			*(tmp + k) = 0;
+		k = MAX_INPUT_LENGTH - 1;
+		while (IS_UTF8_TAIL(out[k])) // don't cut in the middle of an Unicode char
+			k--; // max 3, we have validated
+		out[k] = 0;
 
-			/*
-			 * bah! this was in wrong spot, wouldn't catch it until after
-			 * it had hosed memory by overwriting some huge ass string to
-			 * a little dinky char array.  JAB
-			 */
-
-			if (k > (MAX_INPUT_LENGTH - 1))
-			{
-				k          = MAX_INPUT_LENGTH - 1;
-				*(tmp + k) = 0;
-				snprintf(buffer, MAX_STRING_LENGTH, "Line too long. Truncated to:\r\n%s\r\n", tmp);
-				if (write_to_descriptor(t, buffer) < 0)
-					return (-1);
-
-				/* skip the rest of the line */
-				for (; *(t->buf + i) && !ISNEWL(*(t->buf + i)); i++)
-					;
-			}
-			/* handle '!' to repeat last command */
-			if ((*tmp != '!') || !t->last_input || !t->character || t->connected)
-				strcpy(t->last_input, tmp);
-			else
-				strcpy(tmp, t->last_input);
-
-			if (t)
-				if (t->character && IS_PC(t->character))
-				{
-					t->character->only.pc->recived_data = t->character->only.pc->recived_data + strlen(tmp);
-					recivedbytes                        = recivedbytes + strlen(tmp);
-				}
-			write_to_q(tmp, &t->input, 0);
-
-			snoop_by_ptr = t->snoop.snoop_by_list;
-
-			/*
-			      if (t->snoop.snoop_by) {
-			*/
-			while (snoop_by_ptr)
-			{
-				write_to_q("&+y%&n ", &snoop_by_ptr->snoop_by->desc->output, 1);
-				write_to_q(tmp, &snoop_by_ptr->snoop_by->desc->output, 1);
-				write_to_q("\r\n", &snoop_by_ptr->snoop_by->desc->output, 1);
-
-				snoop_by_ptr = snoop_by_ptr->next;
-			}
-
-			/* find end of entry */
-			for (; ISNEWL(*(t->buf + i)); i++)
-				;
-
-			/* squelch the entry from the buffer */
-			for (squelch = 0;; squelch++)
-				if ((*(t->buf + squelch) = *(t->buf + i + squelch)) == '\0')
-					break;
-			k = 0;
-			i = 0;
-		}
+		char buffer[MAX_STRING_LENGTH];
+		snprintf(buffer, sizeof buffer, "Line too long. Truncated to:\r\n%s\r\n", out);
+		if (write_to_descriptor(t, buffer) < 0)
+			return;
 	}
-	return (1);
+
+	/* handle '!' to repeat last command */
+	if ((*out != '!') || !*t->last_input || !t->character || t->connected)
+		memcpy(t->last_input, out, k + 1);
+	else
+		strcpy(out, t->last_input);
+
+	if (t && t->character && IS_PC(t->character))
+	{
+		t->character->only.pc->recived_data += k;
+		recivedbytes                        += k;
+	}
+	write_to_q(out, &t->input, 0);
+
+	snoop_by_data *snoop_by_ptr = t->snoop.snoop_by_list;
+
+	while (snoop_by_ptr)
+	{
+		write_to_q("&+y%&n ", &snoop_by_ptr->snoop_by->desc->output, 1);
+		write_to_q(out, &snoop_by_ptr->snoop_by->desc->output, 1);
+		write_to_q("\r\n", &snoop_by_ptr->snoop_by->desc->output, 1);
+
+		snoop_by_ptr = snoop_by_ptr->next;
+	}
 }
 
 /*

--- a/src/copyover.c
+++ b/src/copyover.c
@@ -119,11 +119,10 @@ static int write_desc_entry(FILE *fp, P_desc d)
 	entry.gmcp_enabled                   = d->gmcp_enabled;
 	entry.out_compress                   = d->out_compress;
 	entry.mtts_flags                     = d->mtts_flags;
-	entry.charset_detected               = d->charset_detected;
-	strncpy(entry.ttype_client, d->ttype_client, sizeof(entry.ttype_client) - 1);
+	entry.charset_detected               = 0; // removed
+	strncpy(entry.ttype_client, d->client_name, sizeof(entry.ttype_client) - 1);
 	entry.ttype_client[sizeof(entry.ttype_client) - 1] = '\0';
-	strncpy(entry.ttype_terminal, d->ttype_terminal, sizeof(entry.ttype_terminal) - 1);
-	entry.ttype_terminal[sizeof(entry.ttype_terminal) - 1] = '\0';
+	entry.ttype_terminal[0] = '\0'; // removed
 
 	return fwrite(&entry, sizeof(entry), 1, fp) == 1;
 }
@@ -677,11 +676,7 @@ void copyover_recover(int *mother_desc, int *mother_desc_ssl, int *ws_desc)
 		d->term_type                   = desc_entry.term_type;
 		d->gmcp_enabled                = desc_entry.gmcp_enabled;
 		d->mtts_flags                  = desc_entry.mtts_flags;
-		d->charset_detected            = desc_entry.charset_detected;
-		strncpy(d->ttype_client, desc_entry.ttype_client, sizeof(d->ttype_client) - 1);
-		d->ttype_client[sizeof(d->ttype_client) - 1] = '\0';
-		strncpy(d->ttype_terminal, desc_entry.ttype_terminal, sizeof(d->ttype_terminal) - 1);
-		d->ttype_terminal[sizeof(d->ttype_terminal) - 1] = '\0';
+		strlcpy(d->client_name, desc_entry.ttype_client, sizeof(d->client_name));
 		d->ttype_state                                   = TTYPE_COMPLETE; // already negotiated before copyover
 		d->wait                                          = 1;
 		d->prompt_mode                                   = FALSE;

--- a/src/copyover.c
+++ b/src/copyover.c
@@ -687,6 +687,7 @@ void copyover_recover(int *mother_desc, int *mother_desc_ssl, int *ws_desc)
 		d->prompt_mode                                   = FALSE;
 		d->connected                                     = -1; // temp state until player loads
 		used_descs++;
+		check_cp437(d);
 
 		// load character
 		if (desc_entry.player_name[0])

--- a/src/mccp.c
+++ b/src/mccp.c
@@ -296,31 +296,11 @@ int write_to_descriptor(P_desc player, const char *txt)
 	conv_buf[j] = '\0';
 	txt         = conv_buf;
 	total       = j;
-
-	/*
-	 * charset logic:
-	 * - ssl connections: always utf8
-	 * - mtts with utf8 flag: utf8
-	 * - mtts without utf8 flag: cp437
-	 * - zmud/cmud (no mtts support): cp437
-	 * - everyone else: utf8 (modern default)
-	 */
 	char down[j + 1];
-	int  need_cp437 = 0;
 
-	if (!player->sslses)
+	if (player->cp437)
 	{
-		if (player->mtts_flags && !(player->mtts_flags & MTTS_UTF8))
-			need_cp437 = 1;
-		else if (player->ttype_client[0] && (strncasecmp(player->ttype_client, "ZMUD", 4) == 0 || strncasecmp(player->ttype_client, "CMUD", 4) == 0 ||
-		                                     strncasecmp(player->ttype_client, "VT", 2) == 0 || strncasecmp(player->ttype_client, "ANSI", 4) == 0 || strncasecmp(player->ttype_client, "DUMB", 4) == 0))
-			need_cp437 = 1;
-	}
-
-	if (need_cp437)
-	{
-		char *dend = down;
-		downgrade_string(dend, txt, u_cp437);
+		downgrade_string(down, txt, u_cp437);
 		txt   = down;
 		total = strlen(txt);
 	}

--- a/src/mccp.c
+++ b/src/mccp.c
@@ -71,23 +71,23 @@ int send_ga(P_desc desc)
 int parse_telnet_options(P_desc player, char *buf, int buflen)
 {
 	ubyte *p        = (ubyte *)(buf);
-	int    mccp_ver = 0;
 
 	if (buflen < 1 || *p != IAC)
 		return 0;
 
 	switch (*(p + 1))
 	{
+		case IAC: // ignore escaped 255 byte: illegal in UTF-8, redundant in CP437
+			return 2;
 		case DO:
 			switch (*(p + 2))
 			{
 				case TELOPT_COMPRESS:
-					if (mccp_ver < MCCP_VER2) // prefer version 2 over 1
-						mccp_ver = MCCP_VER1;
-					break;
+					compress_start(player, MCCP_VER1);
+					return 3;
 				case TELOPT_COMPRESS2:
-					mccp_ver = MCCP_VER2;
-					break;
+					compress_start(player, MCCP_VER2);
+					return 3;
 				case TELOPT_GMCP:
 					gmcp_handle_negotiation(player, DO);
 					return 3;
@@ -95,7 +95,7 @@ int parse_telnet_options(P_desc player, char *buf, int buflen)
 					player->sga_disabled = 1;
 					return 3;
 			}
-			break;
+			return 3;
 		case DONT:
 			switch (*(p + 2))
 			{
@@ -106,31 +106,31 @@ int parse_telnet_options(P_desc player, char *buf, int buflen)
 					player->sga_disabled = 0;
 					return 3;
 			}
-			/* fall through */
+			return 3;
 		case WILL:
 			if (*(p + 2) == TELOPT_TTYPE)
 				ttype_handle_negotiation(player, WILL);
-			return (*(p + 2) != '\0') ? 3 : 2;
+			return 3;
 		case WONT:
 			if (*(p + 2) == TELOPT_TTYPE)
 				ttype_handle_negotiation(player, WONT);
-			return (*(p + 2) != '\0') ? 3 : 2;
+			return 3;
 		case SB: /* subnegotiation */
 		{
-			int len = 2;
-			while (len < buflen && p[len] != '\0' && !(p[len] == IAC && p[len + 1] == SE))
+			int len = 3;
+			while (len < buflen && !(p[len] == IAC && p[len + 1] == SE))
 				len++;
 
+			if (len > 128) // arbitrary; a telnet subnego is not supposed to be long
+				return 128;
+
 			/* incomplete, wait for more */
-			if (len >= buflen || p[len] == '\0')
+			if (len >= buflen)
 				return 0;
 
-			if (p[len] == IAC && p[len + 1] == SE)
-				len += 2;
-			else
-				return 0;
+			len += 2;
 
-			if (p[2] == TELOPT_TTYPE && len > 4)
+			if (p[2] == TELOPT_TTYPE)
 			{
 				if (p[3] == TELQUAL_IS)
 				{
@@ -151,11 +151,6 @@ int parse_telnet_options(P_desc player, char *buf, int buflen)
 		}
 	}
 
-	if (mccp_ver)
-	{
-		compress_start(player, mccp_ver);
-		return 3;
-	}
 	return 1; /* lets cut at least IAC from stream */
 }
 

--- a/src/mccp.c
+++ b/src/mccp.c
@@ -24,12 +24,12 @@ extern long   sentbytes;
 int mccp_alloc = 0;
 int mccp_free  = 0;
 
-const unsigned char compress_on_str[]  = {IAC, WILL, TELOPT_COMPRESS, '\0'};
-const unsigned char compress2_on_str[] = {IAC, WILL, TELOPT_COMPRESS2, '\0'};
-const unsigned char enable_compress[]  = {IAC, SB, TELOPT_COMPRESS, WILL, SE, '\0'};
-const unsigned char enable_compress2[] = {IAC, SB, TELOPT_COMPRESS2, IAC, SE, '\0'};
-const unsigned char sga_will_str[]     = {IAC, WILL, TELOPT_SGA, '\0'};
-const unsigned char ga_str[]           = {IAC, GA, '\0'};
+const unsigned char compress_on_str[]  = {IAC, WILL, TELOPT_COMPRESS};
+const unsigned char compress2_on_str[] = {IAC, WILL, TELOPT_COMPRESS2};
+const unsigned char enable_compress[]  = {IAC, SB, TELOPT_COMPRESS, WILL, SE};
+const unsigned char enable_compress2[] = {IAC, SB, TELOPT_COMPRESS2, IAC, SE};
+const unsigned char sga_will_str[]     = {IAC, WILL, TELOPT_SGA};
+const unsigned char ga_str[]           = {IAC, GA};
 
 void *zlib_alloc(void *opaque, unsigned int items, unsigned int size);
 void  zlib_free(void *opaque, void *address);
@@ -51,8 +51,8 @@ void zlib_free(void *opaque, void *address)
 
 void advertise_mccp(P_desc desc)
 {
-	write_to_descriptor(desc, (const char *)compress2_on_str);
-	write_to_descriptor(desc, (const char *)compress_on_str);
+	write_to_descriptor_binary(desc, compress2_on_str, sizeof compress2_on_str);
+	write_to_descriptor_binary(desc, compress_on_str, sizeof compress_on_str);
 }
 
 void sga_negotiate(P_desc desc) { write_to_descriptor_binary(desc, sga_will_str, 3); }
@@ -189,11 +189,11 @@ int compress_start(P_desc player, int mccp_version)
 
 	if (mccp_version == MCCP_VER1)
 	{
-		write_to_descriptor(player, (const char *)enable_compress);
+		write_to_descriptor_binary(player, enable_compress, sizeof enable_compress);
 	}
 	else if (mccp_version == MCCP_VER2)
 	{
-		write_to_descriptor(player, (const char *)enable_compress2);
+		write_to_descriptor_binary(player, enable_compress2, sizeof enable_compress2);
 	}
 	else
 	{

--- a/src/mccp.c
+++ b/src/mccp.c
@@ -325,55 +325,10 @@ int write_to_descriptor(P_desc player, const char *txt)
 		total = strlen(txt);
 	}
 
-	if (!player->out_compress)
-	{
-		if (raw_write_to_descriptor(player, txt, total) < 0)
-		{
-			if (conv_buf != static_conv_buf)
-				FREE(conv_buf);
-			return (-1);
-		}
-	}
-	else
-	{
-		if (player && player->z_str)
-		{
-			player->z_str->next_in  = (unsigned char *)txt;
-			player->z_str->avail_in = total;
-
-			while (player->z_str->avail_in)
-			{
-				do
-				{
-					player->z_str->next_out  = (Bytef *)player->out_compress_buf;
-					player->z_str->avail_out = COMPRESS_BUF_SIZE;
-
-					status = deflate(player->z_str, Z_SYNC_FLUSH);
-					if (status != Z_OK)
-					{
-						logit(LOG_DEBUG, "MCCP: deflate failed");
-						if (conv_buf != static_conv_buf)
-							FREE(conv_buf);
-						return (-1);
-					}
-
-					len = (long)player->z_str->next_out - (long)player->out_compress_buf;
-					if (raw_write_to_descriptor(player, player->out_compress_buf, len) < 0)
-					{
-						if (conv_buf != static_conv_buf)
-							FREE(conv_buf);
-						return (-1);
-					}
-
-				} while (player->z_str->avail_out == 0);
-			}
-		}
-	}
-
+	int ret = write_to_descriptor_binary(player, (const unsigned char*)txt, total);
 	if (conv_buf != static_conv_buf)
 		FREE(conv_buf);
-
-	return (0);
+	return ret;
 }
 
 /* never ever call this function, unless you are write_to_descriptor */

--- a/src/mccp.c
+++ b/src/mccp.c
@@ -250,8 +250,7 @@ int compress_end(P_desc player, int flush)
 int write_to_descriptor(P_desc player, const char *txt)
 {
 	int   len, total, status, i, j;
-	char  static_conv_buf[MAX_STRING_LENGTH];
-	char *conv_buf = static_conv_buf;
+	char  conv_buf[MAX_STRING_LENGTH * 2];
 
 	if (player->write_failed)
 		return -1;
@@ -278,10 +277,6 @@ int write_to_descriptor(P_desc player, const char *txt)
 		return 0;
 	}
 
-	if ((len = strlen(txt)) > MAX_STRING_LENGTH * 0.8)
-		CREATE(conv_buf, char, (unsigned int)(len * 1.1), MEM_TAG_BUFFER);
-	// conv_buf = (char *) malloc((unsigned int) (len * 1.1));
-
 	for (i = 0, j = 0; txt[i]; i++)
 	{
 		if (txt[i] == '\n')
@@ -306,8 +301,6 @@ int write_to_descriptor(P_desc player, const char *txt)
 	}
 
 	int ret = write_to_descriptor_binary(player, (const unsigned char*)txt, total);
-	if (conv_buf != static_conv_buf)
-		FREE(conv_buf);
 	return ret;
 }
 

--- a/src/nanny.c
+++ b/src/nanny.c
@@ -1593,9 +1593,9 @@ bool valid_password(P_desc d, char *arg)
 
 void echo_on(P_desc d)
 {
-	char on_string[] = {(char)IAC, (char)WONT, (char)TELOPT_ECHO, (char)TELOPT_NAOFFD, (char)TELOPT_NAOCRD, (char)0};
+	unsigned char on_string[] = {IAC, WONT, TELOPT_ECHO, TELOPT_NAOFFD, TELOPT_NAOCRD};
 
-	SEND_TO_Q(on_string, d);
+	write_to_descriptor_binary(d, on_string, 5);
 }
 
 /*
@@ -1604,14 +1604,9 @@ void echo_on(P_desc d)
 
 void echo_off(P_desc d)
 {
-	char off_string[] = {
-		(char)IAC,
-		(char)WILL,
-		(char)TELOPT_ECHO,
-		(char)0,
-	};
+	unsigned char off_string[] = {IAC, WILL, TELOPT_ECHO};
 
-	SEND_TO_Q(off_string, d);
+	write_to_descriptor_binary(d, off_string, 3);
 }
 
 int number_of_players(void)

--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -3185,6 +3185,7 @@ int  compress_end(P_desc, int);
 void ttype_negotiate(P_desc d);
 void ttype_handle_negotiation(P_desc d, int cmd);
 void ttype_handle_subnegotiation(P_desc d, const unsigned char *data, int len);
+void check_cp437(P_desc d);
 
 /* poisons */
 void poison_lifeleak(int, P_char, char *, int, P_char, struct affected_type *);

--- a/src/structs.h
+++ b/src/structs.h
@@ -1710,6 +1710,7 @@ struct descriptor_data
 	int               max_str;                      /* -                          */
 	char             *name;                         /* name for mail system       */
 	bool              prompt_mode;                  /* control of prompt-printing */
+	int               buflen;
 	char              buf[MAX_QUEUE_LENGTH];        /* buffer for raw input       */
 	char              last_input[MAX_INPUT_LENGTH]; /* the last input         */
 	struct txt_q      output;                       /* q of strings to send       */
@@ -1757,12 +1758,8 @@ struct descriptor_data
 
 	/* ttype/mtts support */
 	int    ttype_state;        /* 0=none, 1=sent_do, 2=cycling, 3=complete */
-	int    ttype_round;        /* mtts round (1-4) */
-	char   ttype_client[64];   /* client name from ttype round 1 */
-	char   ttype_terminal[32]; /* terminal type from round 2 */
 	char   ttype_last[128];    /* last response for duplicate detection */
-	int    mtts_flags;         /* bitvector from round 3 */
-	int    charset_detected;   /* 1 if ttype says client supports utf8 */
+	int    mtts_flags;         /* bitvector */
 	time_t ttype_timeout;      /* when to give up waiting for ttype */
 
 	/* ping/pong for dead connection detection */

--- a/src/structs.h
+++ b/src/structs.h
@@ -1721,6 +1721,7 @@ struct descriptor_data
 	char              tmp_val;                      /* temporary field used in char creation only */
 	char              confirm_state;                /* SAM 7-94, used to allow confirming commands */
 	::byte            term_type;                    /* terminal type, normal or ansi */
+	ubyte             cp437;                        /* no Unicode capability      */
 	char              last_command[MAX_INPUT_LENGTH];
 	P_acct            account;
 	char             *selected_char_name; /* temporary storage for character selection confirmation */

--- a/src/ttype.c
+++ b/src/ttype.c
@@ -4,11 +4,14 @@
  * detects mud clients via ttype negotiation and parses
  * mtts bitvector for terminal capabilities like utf-8.
  *
- * mtts cycling:
- *   round 1: client name (e.g. "MUDLET", "TINTIN++")
- *   round 2: terminal type (e.g. "XTERM-256COLOR")
- *   round 3: "MTTS ###" bitvector with capabilities
- *   round 4: same as round 3 = end of cycling
+ * telnet ttype gives a number of terminal names, meant to be given in the order
+ * from most specific to the least.  Among MUD clients, the first name tends to be
+ * the client's name.  Subsequent values might be the client's version, some common
+ * terminal names, etc.  The end of the list is marked by returning to the first
+ * entry and cycling anew.
+ *
+ * mtts inserts a string "MTTS ###" as one of the names, it's a decimal number
+ * giving reported capabilities.
  */
 
 #include "prototypes.h"
@@ -52,7 +55,6 @@ void ttype_handle_negotiation(P_desc d, int cmd)
 	if (cmd == WILL)
 	{
 		d->ttype_state   = TTYPE_CYCLING;
-		d->ttype_round   = 0;
 		d->ttype_last[0] = '\0';
 		ttype_send_request(d);
 	}
@@ -70,13 +72,6 @@ static void ttype_send_request(P_desc d)
 	if (!d || d->ttype_state != TTYPE_CYCLING)
 		return;
 
-	if (d->ttype_round >= MTTS_MAX_ROUNDS)
-	{
-		d->ttype_state = TTYPE_COMPLETE;
-		return;
-	}
-
-	d->ttype_round++;
 	write_to_descriptor_binary(d, ttype_send, 6);
 }
 
@@ -101,8 +96,6 @@ static void parse_mtts_bitvector(P_desc d, const char *str)
 
 	d->mtts_flags = (int)flags;
 
-	if (flags & MTTS_UTF8)
-		d->charset_detected = 1;
 	check_cp437(d);
 }
 
@@ -159,44 +152,24 @@ void ttype_handle_subnegotiation(P_desc d, const unsigned char *data, int len)
 		return;
 	}
 
-	/* check if same as last response - signals end of cycling */
-	if (d->ttype_last[0] && strcmp(term_type, d->ttype_last) == 0)
+	/* the list should be complete if it goes back to the first entry, but check for looping on
+	   the last response, too */
+	if (d->ttype_last[0] && !(strcmp(term_type, d->ttype_last) && strcmp(term_type, d->client_name)))
 	{
 		d->ttype_state = TTYPE_COMPLETE;
 		return;
 	}
 
 	/* store for duplicate detection */
-	strncpy(d->ttype_last, term_type, sizeof(d->ttype_last) - 1);
-	d->ttype_last[sizeof(d->ttype_last) - 1] = '\0';
+	strlcpy(d->ttype_last, term_type, sizeof(d->ttype_last));
 
-	/* process based on round */
-	switch (d->ttype_round)
-	{
-		case 1:
-			/* round 1: client name */
-			strncpy(d->ttype_client, term_type, sizeof(d->ttype_client) - 1);
-			d->ttype_client[sizeof(d->ttype_client) - 1] = '\0';
-			/* also set client_name for display */
-			strncpy(d->client_name, term_type, sizeof(d->client_name) - 1);
-			d->client_name[sizeof(d->client_name) - 1] = '\0';
-			break;
+	/* take the first ttype as client name */
+	if (!*d->client_name)
+		strlcpy(d->client_name, term_type, sizeof(d->client_name));
 
-		case 2:
-			/* round 2: terminal type */
-			strncpy(d->ttype_terminal, term_type, sizeof(d->ttype_terminal) - 1);
-			d->ttype_terminal[sizeof(d->ttype_terminal) - 1] = '\0';
-			break;
-
-		case 3:
-		case 4:
-			/* round 3/4: mtts bitvector */
-			if (strncasecmp(term_type, "MTTS", 4) == 0)
-			{
-				parse_mtts_bitvector(d, term_type);
-			}
-			break;
-	}
+	/* MTTS response can come as any entry; typically not first but checking doesn't hurt */
+	if (strncasecmp(term_type, "MTTS", 4) == 0)
+		parse_mtts_bitvector(d, term_type);
 
 	/* request next round */
 	ttype_send_request(d);
@@ -218,13 +191,13 @@ void check_cp437(P_desc d)
 		d->cp437 = 0;
 	else if (d->mtts_flags)
 		d->cp437 = !(d->mtts_flags & MTTS_UTF8);
-	else if (!d->ttype_client[0])
+	else if (!d->client_name[0])
 		d->cp437 = 0;
-	else if (strncasecmp(d->ttype_client, "ZMUD", 4) == 0
-		 || strncasecmp(d->ttype_client, "CMUD", 4) == 0
-		 || strncasecmp(d->ttype_client, "VT", 2) == 0
-		 || strncasecmp(d->ttype_client, "ANSI", 4) == 0
-		 || strncasecmp(d->ttype_client, "DUMB", 4) == 0)
+	else if (strncasecmp(d->client_name, "ZMUD", 4) == 0
+		 || strncasecmp(d->client_name, "CMUD", 4) == 0
+		 || strncasecmp(d->client_name, "VT", 2) == 0
+		 || strncasecmp(d->client_name, "ANSI", 4) == 0
+		 || strncasecmp(d->client_name, "DUMB", 4) == 0)
 	{
 		d->cp437 = 1;
 	}

--- a/src/ttype.c
+++ b/src/ttype.c
@@ -103,6 +103,7 @@ static void parse_mtts_bitvector(P_desc d, const char *str)
 
 	if (flags & MTTS_UTF8)
 		d->charset_detected = 1;
+	check_cp437(d);
 }
 
 /*
@@ -199,4 +200,34 @@ void ttype_handle_subnegotiation(P_desc d, const unsigned char *data, int len)
 
 	/* request next round */
 	ttype_send_request(d);
+}
+
+// recheck UTF8 capability
+void check_cp437(P_desc d)
+{
+	/*
+	 * charset logic:
+	 * - ssl connections: always utf8
+	 * - mtts with utf8 flag: utf8
+	 * - mtts without utf8 flag: cp437
+	 * - zmud/cmud (no mtts support): cp437
+	 * - everyone else: utf8 (modern default)
+	 */
+
+	if (d->sslses)
+		d->cp437 = 0;
+	else if (d->mtts_flags)
+		d->cp437 = !(d->mtts_flags & MTTS_UTF8);
+	else if (!d->ttype_client[0])
+		d->cp437 = 0;
+	else if (strncasecmp(d->ttype_client, "ZMUD", 4) == 0
+		 || strncasecmp(d->ttype_client, "CMUD", 4) == 0
+		 || strncasecmp(d->ttype_client, "VT", 2) == 0
+		 || strncasecmp(d->ttype_client, "ANSI", 4) == 0
+		 || strncasecmp(d->ttype_client, "DUMB", 4) == 0)
+	{
+		d->cp437 = 1;
+	}
+	else
+		d->cp437 = 0;
 }

--- a/src/ttype.h
+++ b/src/ttype.h
@@ -25,8 +25,6 @@
 #define MTTS_TRUECOLOR     256
 #define MTTS_MNES          512
 
-#define MTTS_MAX_ROUNDS 4
-
 /* function prototypes */
 void ttype_negotiate(P_desc d);
 void ttype_handle_negotiation(P_desc d, int cmd);

--- a/src/unicode.c
+++ b/src/unicode.c
@@ -198,17 +198,6 @@ void downgrade_string(char *out, const char *in, const unimap &conv)
 {
 	while (*in)
 	{
-		// let TELNET through unmolested
-		if (*in == (char)255)
-		{
-			// Hack!  The only SB/SE we use is COMPRESS.
-			int len = in[1] == (char)250 ? 5 : 3;
-			for (int i = 0; i < len; i++)
-				if (*in) // end in a string inside a TELNET command?  Can't happen but...
-					*out++ = *in++;
-			continue;
-		}
-
 		int c = get_utf8(in);
 		int r = conv[c];
 		if (!r)

--- a/src/unicode.c
+++ b/src/unicode.c
@@ -210,3 +210,38 @@ void downgrade_string(char *out, const char *in, const unimap &conv)
 	}
 	*out = 0;
 }
+
+void upgrade_cp437_and_dollars(char *out, const char *in)
+{
+	while (*in)
+	{
+		int c = (unsigned char)*in++;
+		if (c < ' ') // controls are illegal, including \n
+			continue;
+		if (c == '$')
+			*out++ = '$';
+		put_utf8(out, cp437_u[c]);
+	}
+	*out = 0;
+}
+
+bool validate_utf8_and_dollars(char *out, const char *in)
+{
+	bool err = false;
+
+	while (*in)
+	{
+		int c = get_utf8(in);
+		if (c < ' ') // controls are illegal, including \n
+			continue;
+		if (c == '$')
+			*out++ = '$';
+		if (c < 127 || ascii[c]) // rule: anything we can downgrade is allowed
+			put_utf8(out, c);
+		else
+			err = true; // complain
+	}
+	*out = 0;
+
+	return err;
+}

--- a/src/unicode.h
+++ b/src/unicode.h
@@ -2,6 +2,7 @@
 
 // Unicode replacement char
 #define UNI_BAD 0xFFFD
+#define IS_UTF8_TAIL(x) (((x) & 0xc0) == 0x80)
 
 typedef unsigned short ushort;
 
@@ -31,3 +32,6 @@ void put_utf8(char *&d, int v);
 void downgrade_string(char *out, const char *in, const unimap &conv);
 
 extern unimap u_cp437;
+
+void upgrade_cp437_and_dollars(char *out, const char *in);
+bool validate_utf8_and_dollars(char *out, const char *in);


### PR DESCRIPTION
Should unbreak zMUD.

Beside correctness fixes, the new code also allows Unicode input.  It remains a question what of these should be allowed on acc/nchat/says, and what just for map glyphs.