### PR TITLE
Fix container weight propagation and capacity checks.

### DIFF
--- a/src/actobj.c
+++ b/src/actobj.c
@@ -1934,7 +1934,7 @@ bool put(P_char ch, P_obj o_obj, P_obj s_obj, int showit)
 					return (FALSE);
 				}
 
-				if (((GET_OBJ_WEIGHT(s_obj) + GET_OBJ_WEIGHT(o_obj)) <= (s_obj->value[0])) ||
+				if (((container_total_weight(s_obj) + GET_OBJ_WEIGHT(o_obj)) <= (s_obj->value[0])) ||
 				    ((s_obj->value[0] == -1) && (GET_ITEM_TYPE(s_obj) == ITEM_STORAGE || GET_ITEM_TYPE(s_obj) == ITEM_CONTAINER)))
 				{
 
@@ -5951,7 +5951,7 @@ void do_empty(P_char ch, char *argument, int cmd)
 	while ((content = obj1->contains) != NULL)
 	{
 
-		if (((GET_OBJ_WEIGHT(obj2) + GET_OBJ_WEIGHT(content)) > obj1->value[0]) && (obj1->value[0] != -1))
+		if (((container_total_weight(obj2) + GET_OBJ_WEIGHT(content)) > obj2->value[0]) && (obj2->value[0] != -1))
 		{
 			act("$P will not fit in $p.", FALSE, ch, obj2, (void *)content, TO_CHAR);
 			send_to_char_f(ch, "You moved %d item%s from %s to %s.\n", count, count == 1 ? "" : "s", OBJ_SHORT(obj1), OBJ_SHORT(obj2));

--- a/src/handler.c
+++ b/src/handler.c
@@ -77,6 +77,103 @@ int  map_view_distance(P_char ch, int room);
 bool leave_safe_room(P_char ch);
 void add_weight(P_obj obj, int weight);
 
+static bool obj_is_container_type(P_obj obj)
+{
+	if (!obj)
+	{
+		return FALSE;
+	}
+	return (obj->type == ITEM_CONTAINER || obj->type == ITEM_QUIVER || obj->type == ITEM_STORAGE || obj->type == ITEM_CORPSE);
+}
+
+static int obj_prototype_weight(P_obj obj)
+{
+	P_obj proto;
+	int   w;
+
+	if (!obj || obj->R_num < 0)
+	{
+		return 0;
+	}
+	proto = read_object(obj->R_num, REAL);
+	if (!proto)
+	{
+		return 0;
+	}
+	w = proto->weight;
+	extract_obj(proto, TRUE);
+	return w;
+}
+
+static int sum_direct_contents_weight(P_obj cont)
+{
+	P_obj o;
+	int   w = 0;
+
+	for (o = cont->contains; o; o = o->next_content)
+	{
+		w += GET_OBJ_WEIGHT(o);
+	}
+	return w;
+}
+
+static void encumbrance_adjust(P_char ch, int weight)
+{
+	if (!ch || !weight)
+	{
+		return;
+	}
+	GET_CARRYING_W(ch) += weight;
+}
+
+/*
+ * Recompute container weight from prototype shell + contents; repair carry_weight if wrong.
+ */
+void recalc_container_weight(P_obj cont)
+{
+	int delta;
+	int new_weight;
+	int shell;
+	int contents;
+
+	if (!obj_is_container_type(cont))
+	{
+		return;
+	}
+
+	shell    = obj_prototype_weight(cont);
+	contents = sum_direct_contents_weight(cont);
+	new_weight = shell + contents;
+	delta      = new_weight - cont->weight;
+	if (!delta)
+	{
+		return;
+	}
+	add_weight(cont, delta);
+}
+
+void container_reset_empty_weight(P_obj cont)
+{
+	if (!obj_is_container_type(cont))
+	{
+		return;
+	}
+	cont->weight = obj_prototype_weight(cont);
+}
+
+int container_total_weight(P_obj cont)
+{
+	if (!cont)
+	{
+		return 0;
+	}
+	if (obj_is_container_type(cont))
+	{
+		recalc_container_weight(cont);
+	}
+	return GET_OBJ_WEIGHT(cont);
+}
+
 /*
  * called every 20 seconds, just loops through chars doing...stuff
  */
@@ -2491,8 +2588,7 @@ void obj_to_obj(P_obj obj, P_obj obj_to)
 		}
 	}
 
-	if (obj->weight > 0)
-		add_weight(obj_to, obj->weight);
+	add_weight(obj_to, obj->weight);
 	/* Broken out into a recursive function; neater and more correct for handling negative weights properly.
 	  wgt = GET_OBJ_WEIGHT(obj);
 	  for (tmp_obj = obj->loc.inside; wgt && tmp_obj;
@@ -2555,8 +2651,7 @@ void obj_to_obj_at_end(P_obj obj, P_obj obj_to)
 	obj->loc.inside = obj_to;
 	append_obj_to_list(&obj_to->contains, obj);
 
-	if (obj->weight > 0)
-		add_weight(obj_to, obj->weight);
+	add_weight(obj_to, obj->weight);
 
 	mark_container_dirty(obj_to);
 }
@@ -2633,11 +2728,7 @@ void obj_from_obj(P_obj obj)
 			tmp->next_content = obj->next_content;
 		}
 
-		// Subtract weight from containers container
-		if (obj->weight > 0)
-		{
-			add_weight(obj_from, -(obj->weight));
-		}
+		add_weight(obj_from, -(obj->weight));
 		/*    wgt = GET_OBJ_WEIGHT(obj);
 		    for( tmp = obj->loc.inside; wgt && tmp; tmp = OBJ_INSIDE(tmp) ? tmp->loc.inside : NULL )
 		    {
@@ -4432,86 +4523,62 @@ bool leave_safe_room(P_char ch)
 // This function adds weight to the object, then adds weight to its container/holder/wearer,
 //   but only the amount of weight above the magical weightlessness of said object.
 // This function handles adding a negative weight properly as well.
+// Worn objects apply half the propagated delta to carry_weight (matches equip_char / unequip_char).
+static void propagate_weight_delta(P_obj obj, int weight)
+{
+	if (!obj || !weight)
+	{
+		return;
+	}
+
+	switch (obj->loc_p)
+	{
+		case LOC_WORN:
+			encumbrance_adjust(obj->loc.wearing, weight / 2);
+			break;
+		case LOC_CARRIED:
+			encumbrance_adjust(obj->loc.carrying, weight);
+			break;
+		case LOC_INSIDE:
+			add_weight(obj->loc.inside, weight);
+			break;
+		case LOC_ROOM:
+		case LOC_NOWHERE:
+		default:
+			break;
+	}
+}
+
 void add_weight(P_obj obj, int weight)
 {
+	int carry_delta;
+
+	if (!obj || !weight)
+	{
+		return;
+	}
+
 	// If we start with a negative weight.
 	if (obj->weight < 0)
 	{
-		// Add the new amount of weight (Note: obj->weight stays negative if weight is negative).
 		obj->weight += weight;
-		// If we go above the 'weightlessness' of obj, then add to the container/holder/wearer.
 		if (obj->weight > 0)
 		{
-			switch (obj->loc_p)
-			{
-				case LOC_WORN:
-					GET_CARRYING_W(obj->loc.wearing) += obj->weight;
-					break;
-				case LOC_CARRIED:
-					GET_CARRYING_W(obj->loc.carrying) += obj->weight;
-					break;
-				case LOC_INSIDE:
-					// Call recursively, since the containing object might also have a weightless factor.
-					add_weight(obj->loc.inside, obj->weight);
-					break;
-				case LOC_ROOM:
-				case LOC_NOWHERE:
-				default:
-					break;
-			}
+			carry_delta = obj->weight;
+			propagate_weight_delta(obj, carry_delta);
 		}
 	}
-	// If we start with a positive weight (or 0)
 	else
 	{
-		// Add the new amount of weight (Note: obj->weight might become negative if weight is negative).
 		obj->weight += weight;
-		// If weight stayed positive, just adjust owner/container weight (works for both positive and negative weight).
 		if (obj->weight > 0)
 		{
-			switch (obj->loc_p)
-			{
-				case LOC_WORN:
-					GET_CARRYING_W(obj->loc.wearing) += weight;
-					break;
-				case LOC_CARRIED:
-					GET_CARRYING_W(obj->loc.carrying) += weight;
-					break;
-				case LOC_INSIDE:
-					// Call recursively, since the containing object might also have a weightless factor.
-					add_weight(obj->loc.inside, weight);
-					break;
-				case LOC_ROOM:
-				case LOC_NOWHERE:
-				default:
-					break;
-			}
+			propagate_weight_delta(obj, weight);
 		}
-		// We added a negative weight that dropped obj below 0... fun.
 		else
 		{
-			// We now shift weight to the amount of change to get obj from its previous weight to 0.
-			//   This is because once a container becomes weightless, it doesn't further affect the carrier/etc.
-			// To do this, we subtract the new obj->weight (obj->old_weight+weight) from weight, which yields the
-			//   negative of the original obj->weight.
-			weight -= obj->weight;
-			switch (obj->loc_p)
-			{
-				case LOC_WORN:
-					GET_CARRYING_W(obj->loc.wearing) += weight;
-					break;
-				case LOC_CARRIED:
-					GET_CARRYING_W(obj->loc.carrying) += weight;
-					break;
-				case LOC_INSIDE:
-					// Call recursively, since the containing object might also have a weightless factor.
-					add_weight(obj->loc.inside, weight);
-					break;
-				case LOC_ROOM:
-				case LOC_NOWHERE:
-				default:
-					break;
-			}
+			carry_delta = weight - obj->weight;
+			propagate_weight_delta(obj, carry_delta);
 		}
 	}
 }

--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -1232,6 +1232,9 @@ void                  extract_obj(P_obj obj, int gone_for_good = FALSE); // Only
                                                                          //   and it's going away completely, then use.
 void                   obj_from_char(P_obj);
 void                   obj_from_obj(P_obj);
+void                   recalc_container_weight(P_obj);
+void                   container_reset_empty_weight(P_obj);
+int                    container_total_weight(P_obj);
 void                   obj_from_room(P_obj);
 void                   obj_to_char(P_obj obj, P_char ch);
 void                   obj_to_char_at_end(P_obj obj, P_char ch);

--- a/src/rogues.c
+++ b/src/rogues.c
@@ -49,7 +49,7 @@ void do_slip(P_char ch, char *argument, int cmd)
 		if (bits && bits2 && (container->type == ITEM_CONTAINER))
 		{
 			// Will it fit?
-			if (((GET_OBJ_WEIGHT(obj) + GET_OBJ_WEIGHT(container)) <= container->value[0]) || ((container->value[0] == -1)))
+			if (((GET_OBJ_WEIGHT(obj) + container_total_weight(container)) <= container->value[0]) || ((container->value[0] == -1)))
 			{
 				putsuc = put(ch, obj, container, FALSE);
 				act("You slip $p into $P...", TRUE, ch, obj, container, TO_CHAR);

--- a/src/sql_player.c
+++ b/src/sql_player.c
@@ -2274,9 +2274,6 @@ bool sql_load_player_pets(P_char ch)
 					{
 						if (items[j].db_id == items[i].container_id && items[j].obj)
 						{
-							// container weight is stored with total contents weight
-							// need to remove the weight from the container since obj_to_obj will add it again
-							items[j].obj->weight -= items[i].obj->weight;
 							obj_to_obj(items[i].obj, items[j].obj);
 							break;
 						}
@@ -2289,6 +2286,14 @@ bool sql_load_player_pets(P_char ch)
 				else
 				{
 					obj_to_char(items[i].obj, pet);
+				}
+			}
+
+			for (int k = 0; k < item_count; k++)
+			{
+				if (items[k].obj)
+				{
+					recalc_container_weight(items[k].obj);
 				}
 			}
 		}
@@ -3192,12 +3197,17 @@ bool sql_load_player_items(P_char ch)
 		{
 			if (item_ids[j] == container_ids[i] && items[j])
 			{
-				// container weight is stored with total contents weight
-				// need to remove the weight from the container since obj_to_obj will add it again
-				items[j]->weight -= items[i]->weight;
 				obj_to_obj(items[i], items[j]);
 				break;
 			}
+		}
+	}
+
+	for (int j = 0; j < loaded_count; j++)
+	{
+		if (items[j])
+		{
+			recalc_container_weight(items[j]);
 		}
 	}
 


### PR DESCRIPTION
Recalc container weight from prototype plus contents, apply half delta when worn, and remove SQL load double-subtract so put/get and relog stay consistent.