### PR TITLE
Deramuth ferry

### DIFF
--- a/src/ferryact.c
+++ b/src/ferryact.c
@@ -163,7 +163,7 @@ const struct ferry_definition ferries[] = {
 		10000,                  // ticket price
 		(struct ferry_definition::stop_info[]){         // stops
 			{
-				83788, 
+				83787,
 				"&+WDeramuth Port&N"
 			}, 
 			{


### PR DESCRIPTION
Was unusable due to two ticket automats being in a single room.