### PR TITLE
fix(input): harden Telnet and login boundaries

### DIFF
--- a/src/account.c
+++ b/src/account.c
@@ -476,7 +476,6 @@ void display_account_menu(P_desc d, char *arg)
 
 void confirm_account(P_desc d, char *arg)
 {
-	char debug_buf[512];
 
 	if (!arg)
 	{
@@ -502,18 +501,6 @@ void confirm_account(P_desc d, char *arg)
 		}
 	}
 	*dst = '\0';
-
-	// Debug output
-	snprintf(debug_buf,
-	         512,
-	         "\r\n&+YDEBUG: Entered='%s' (len=%d)&n\r\n&+YDEBUG: Fixed='%s' (len=%d)&n\r\n&+YDEBUG: Stored='%s' (len=%d)&n\r\n",
-	         arg,
-	         (int)strlen(arg),
-	         fixed_input,
-	         (int)strlen(fixed_input),
-	         d->account->acct_confirmation ? d->account->acct_confirmation : "NULL",
-	         d->account->acct_confirmation ? (int)strlen(d->account->acct_confirmation) : 0);
-	SEND_TO_Q(debug_buf, d);
 
 	if (str_cmp(fixed_input, d->account->acct_confirmation))
 	{

--- a/src/comm.c
+++ b/src/comm.c
@@ -14,6 +14,7 @@
 #include "interp.h"
 #include "utility.h"
 #include "utils.h"
+#include <algorithm>
 #include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -1101,7 +1102,7 @@ void game_loop(int port, int sslport)
 
 			/* check for hella long wait time here..  bandaid solution but it should (sort of) work */
 
-			if ((!t_ch || (t_ch && (CAN_ACT(t_ch) && (!IS_SET(t_ch->specials.affected_by, AFF_CHARM) || (point->original))))) && get_from_q(&point->input, comm))
+			if ((!t_ch || (t_ch && (CAN_ACT(t_ch) && (!IS_SET(t_ch->specials.affected_by, AFF_CHARM) || (point->original))))) && get_from_q(&point->input, comm, sizeof(comm)))
 			{
 
 				if (t_ch)
@@ -1443,7 +1444,7 @@ void game_loop(int port, int sslport)
  * ******************************************************************
  */
 
-int get_from_q(struct txt_q *queue, char *dest)
+int get_from_q(struct txt_q *queue, char *dest, size_t dest_size)
 {
 	struct txt_block *tmp;
 
@@ -1453,7 +1454,7 @@ int get_from_q(struct txt_q *queue, char *dest)
 		logit(LOG_COMM, "call to get_from_q with NULL queue");
 		return (0);
 	}
-	if (!dest)
+	if (!dest || dest_size == 0)
 	{
 		logit(LOG_COMM, "call to get_from_q with bogus string");
 		return (0);
@@ -1464,8 +1465,13 @@ int get_from_q(struct txt_q *queue, char *dest)
 	if (!queue->head)
 		return (0);
 
-	tmp = queue->head;
-	strcpy(dest, queue->head->text);
+	tmp             = queue->head;
+	size_t text_len = strlen(queue->head->text);
+	size_t copy_len = std::min(text_len, dest_size - 1);
+	memcpy(dest, queue->head->text, copy_len);
+	dest[copy_len] = '\0';
+	if (copy_len != text_len)
+		logit(LOG_COMM, "get_from_q truncated %zu-byte queue entry to %zu bytes", text_len, copy_len);
 	queue->head = queue->head->next;
 
 	FREE(tmp->text);
@@ -1570,9 +1576,9 @@ void flush_queues(P_desc d)
 {
 	char str[MAX_STRING_LENGTH];
 
-	while (get_from_q(&d->output, str))
+	while (get_from_q(&d->output, str, sizeof(str)))
 		;
-	while (get_from_q(&d->input, str))
+	while (get_from_q(&d->input, str, sizeof(str)))
 		;
 }
 
@@ -2762,7 +2768,7 @@ int process_output(P_desc t)
 	make_prompt(t);
 
 	/* Cycle thru output queue */
-	while (get_from_q(&t->output, buf))
+	while (get_from_q(&t->output, buf, sizeof(buf)))
 	{
 #if 0
     if( PLR_FLAGGED(realChar, PLR_SMARTPROMPT) )
@@ -3015,7 +3021,13 @@ int process_input(P_desc t)
 		{
 			int consumed = parse_telnet_options(t, buf + i, len - i);
 			if (consumed <= 0)
-				goto incomplete; // partial; need to wait for more
+			{
+				/* Preserve an incomplete IAC sequence and the current line for the next read. */
+				memmove(bp, buf + i, (size_t)(len - i));
+				bp += len - i;
+				t->buflen = bp - buf;
+				return 0;
+			}
 			i += consumed - 1;
 			break; /* prevent fall-through to backspace handler */
 		}
@@ -3037,7 +3049,6 @@ int process_input(P_desc t)
 		}
 	}
 
-incomplete:
 	if (bp - buf > MAX_INPUT_LENGTH - 1)
 	{
 		// is it even a good idea to process it anyway?

--- a/src/comm.c
+++ b/src/comm.c
@@ -855,7 +855,7 @@ void game_loop(int port, int sslport)
 			 */
 
 			if ((point->descriptor == ident_ans_buf.desc) && (*((time_t *)(point->login + 4)) == ident_ans_buf.stamp))
-				strcpy(point->login, ident_ans_buf.name);
+				strlcpy(point->login, ident_ans_buf.name, sizeof(point->login));
 
 			if ((point->descriptor == host_ans_buf.desc) && !strncmp(host_ans_buf.addr, point->host /*+ 3 */, strlen(host_ans_buf.addr)))
 			{

--- a/src/comm.c
+++ b/src/comm.c
@@ -1104,6 +1104,8 @@ void game_loop(int port, int sslport)
 
 			if ((!t_ch || (t_ch && (CAN_ACT(t_ch) && (!IS_SET(t_ch->specials.affected_by, AFF_CHARM) || (point->original))))) && get_from_q(&point->input, comm, sizeof(comm)))
 			{
+				if (point->input.blocks < MAX_INPUT_QUEUE_COMMANDS / 2 && point->input.bytes < MAX_INPUT_QUEUE_BYTES / 2)
+					point->input_overflow_warned = false;
 
 				if (t_ch)
 				{
@@ -1473,6 +1475,14 @@ int get_from_q(struct txt_q *queue, char *dest, size_t dest_size)
 	if (copy_len != text_len)
 		logit(LOG_COMM, "get_from_q truncated %zu-byte queue entry to %zu bytes", text_len, copy_len);
 	queue->head = queue->head->next;
+	if (queue->bytes >= text_len)
+		queue->bytes -= text_len;
+	else
+		queue->bytes = 0;
+	if (queue->blocks > 0)
+		queue->blocks--;
+	if (!queue->head)
+		queue->tail = NULL;
 
 	FREE(tmp->text);
 	FREE(tmp);
@@ -1512,6 +1522,8 @@ void write_to_q(const char *txt, struct txt_q *queue, const int flag)
 
 		n_new->next = NULL;
 		queue->head = queue->tail = n_new;
+		queue->bytes             = txtlen;
+		queue->blocks            = 1;
 		return;
 	}
 
@@ -1524,6 +1536,7 @@ void write_to_q(const char *txt, struct txt_q *queue, const int flag)
 		RECREATE(queue->tail->text, char, (txtlen + taillen + 1));
 
 		strcat(queue->tail->text, txt);
+		queue->bytes += txtlen;
 		return;
 	}
 	/* nope, it needs to be sent, just add a queue entry */
@@ -1535,6 +1548,34 @@ void write_to_q(const char *txt, struct txt_q *queue, const int flag)
 	queue->tail->next = n_new;
 	queue->tail       = n_new;
 	n_new->next       = NULL;
+	queue->bytes += txtlen;
+	queue->blocks++;
+}
+
+static void warn_input_overflow(P_desc d)
+{
+	if (!d || d->input_overflow_warned)
+		return;
+	d->input_overflow_warned = true;
+	logit(LOG_COMM, "Input queue limit reached for descriptor %d", d->descriptor);
+	write_to_descriptor(d, "Too much pending input; excess commands were discarded.\r\n");
+}
+
+int write_to_input_q(P_desc d, const char *txt)
+{
+	if (!d || !txt)
+		return 0;
+
+	size_t txtlen = strlen(txt);
+	if (txtlen >= MAX_STRING_LENGTH || d->input.blocks >= MAX_INPUT_QUEUE_COMMANDS ||
+	    d->input.bytes > MAX_INPUT_QUEUE_BYTES || txtlen > MAX_INPUT_QUEUE_BYTES - d->input.bytes)
+	{
+		warn_input_overflow(d);
+		return 0;
+	}
+
+	write_to_q(txt, &d->input, 0);
+	return 1;
 }
 
 /*
@@ -2933,8 +2974,9 @@ int process_output(P_desc t)
 
 int process_input(P_desc t)
 {
-	int            thisround, begin;
-	char           tmp[MAX_INPUT_LENGTH + 3], *buf, *bp;
+	int          thisround, begin;
+	unsigned int lines_processed = 0;
+	char         tmp[MAX_INPUT_LENGTH + 3], *buf, *bp;
 
 	/* WebSocket connections use their own input processing */
 	if (t->websocket)
@@ -3012,6 +3054,12 @@ int process_input(P_desc t)
 			break;
 
 		case '\n':
+			if (++lines_processed > MAX_INPUT_LINES_PER_READ)
+			{
+				warn_input_overflow(t);
+				t->buflen = 0;
+				return 0;
+			}
 			*bp = 0;
 			process_line(t, buf);
 			bp = buf;
@@ -3121,7 +3169,7 @@ static void process_line(P_desc t, char *in)
 		t->character->only.pc->recived_data += k;
 		recivedbytes                        += k;
 	}
-	write_to_q(out, &t->input, 0);
+	write_to_input_q(t, out);
 
 	snoop_by_data *snoop_by_ptr = t->snoop.snoop_by_list;
 

--- a/src/config.h
+++ b/src/config.h
@@ -136,7 +136,10 @@
 #define MAX_QUESTS              2000   /* max allowable quests */
 #define MAX_QUEUE_LENGTH        4800   /* 60 80 character lines */
 #define MAX_SEASONS             4      /* maximum number of seasons in a zone */
-#define MAX_STRING_LENGTH       65536  /* 819+ 80 character lines */
+#define MAX_STRING_LENGTH        65536  /* 819+ 80 character lines */
+#define MAX_INPUT_LINES_PER_READ 128    /* cap work from newline floods per socket event */
+#define MAX_INPUT_QUEUE_COMMANDS 256    /* preserve bursts without unbounded command backlog */
+#define MAX_INPUT_QUEUE_BYTES    MAX_STRING_LENGTH
 #define MAX_LOG_LEN             100000 /* MAX LOGGING */
 #define MAX_TONGUE              29     /* number of defined tongues */
 #define MAX_TRADE               12     /* shops, max number of item types they trade in  */

--- a/src/mccp.c
+++ b/src/mccp.c
@@ -74,6 +74,10 @@ int parse_telnet_options(P_desc player, char *buf, int buflen)
 
 	if (buflen < 1 || *p != IAC)
 		return 0;
+	if (buflen < 2)
+		return 0;
+	if (buflen < 3 && (p[1] == DO || p[1] == DONT || p[1] == WILL || p[1] == WONT))
+		return 0;
 
 	switch (*(p + 1))
 	{

--- a/src/nanny.c
+++ b/src/nanny.c
@@ -2579,7 +2579,7 @@ void select_terminal(P_desc d, char *arg)
 {
 	int  term;
 	int  temp = 1;
-	char temp_buf[200];
+	char temp_buf[MAX_INPUT_LENGTH];
 
 	if ((term = (int)strtol(arg, NULL, 0)) == 0)
 	{
@@ -2599,13 +2599,13 @@ void select_terminal(P_desc d, char *arg)
 		case TERM_MSP:
 			d->term_type = TERM_MSP;
 			arg          = one_argument(arg, temp_buf);
-			strcpy(d->client_str, arg);
+			strlcpy(d->client_str, arg, sizeof(d->client_str));
 			SEND_TO_Q(greetinga, d);
 			break;
 		case TERM_ANSI:
 			d->term_type = TERM_ANSI;
 			arg          = one_argument(arg, temp_buf);
-			strcpy(d->client_str, arg);
+			strlcpy(d->client_str, arg, sizeof(d->client_str));
 
 			temp = number(1, NUM_ANSI_LOGINS);
 			switch (temp)

--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -751,6 +751,7 @@ void        append_prompt(P_char, char *);
 int         wizconnectsite(char *, char *, int);
 int         find_color_entry(int);
 int         get_from_q(struct txt_q *, char *, size_t);
+int         write_to_input_q(P_desc, const char *);
 int         init_socket(int);
 int         process_input(P_desc);
 int         process_output(P_desc);

--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -750,7 +750,7 @@ void NukeChessBoard(P_obj);
 void        append_prompt(P_char, char *);
 int         wizconnectsite(char *, char *, int);
 int         find_color_entry(int);
-int         get_from_q(struct txt_q *, char *);
+int         get_from_q(struct txt_q *, char *, size_t);
 int         init_socket(int);
 int         process_input(P_desc);
 int         process_output(P_desc);

--- a/src/structs.h
+++ b/src/structs.h
@@ -1566,6 +1566,8 @@ struct txt_q
 {
 	struct txt_block *head;
 	struct txt_block *tail;
+	size_t            bytes;
+	size_t            blocks;
 };
 
 /* modes of connectedness */
@@ -1706,6 +1708,7 @@ struct descriptor_data
 	char             *name;                         /* name for mail system       */
 	bool              prompt_mode;                  /* control of prompt-printing */
 	int               buflen;
+	bool              input_overflow_warned;
 	char              buf[MAX_QUEUE_LENGTH];        /* buffer for raw input       */
 	char              last_input[MAX_INPUT_LENGTH]; /* the last input         */
 	struct txt_q      output;                       /* q of strings to send       */

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -978,11 +978,11 @@ static void websocket_handle_message(struct descriptor_data *d, int opcode, char
 				/* in-game: pass raw text as command */
 				if (data_item && cJSON_IsString(data_item))
 				{
-					write_to_q(data_item->valuestring, &d->input, 0);
+					write_to_input_q(d, data_item->valuestring);
 				}
 				else if (cmd)
 				{
-					write_to_q(cmd, &d->input, 0);
+					write_to_input_q(d, cmd);
 				}
 			}
 			cJSON_Delete(json);
@@ -992,7 +992,7 @@ static void websocket_handle_message(struct descriptor_data *d, int opcode, char
 			/* not valid json - treat as raw text command if in game */
 			if (d->connected == CON_PLAYING)
 			{
-				write_to_q(payload, &d->input, 0);
+				write_to_input_q(d, payload);
 			}
 		}
 	}

--- a/src/ws_handlers.c
+++ b/src/ws_handlers.c
@@ -656,7 +656,7 @@ void ws_send_full_game_state(struct descriptor_data *d)
 	}
 
 	/* send a "look" to show the room */
-	write_to_q("look", &d->input, 0);
+	write_to_input_q(d, "look");
 }
 
 /* send auth failed message */
@@ -991,7 +991,7 @@ void ws_cmd_enter(struct descriptor_data *d, cJSON *data)
 	d->selected_char_name = str_dup(c->charname);
 
 	/* queue 'y' to confirm character selection */
-	write_to_q("y", &d->input, 0);
+	write_to_input_q(d, "y");
 	d->connected = CON_ACCT_CONFIRM_CHAR;
 }
 
@@ -1022,7 +1022,7 @@ void ws_cmd_game(struct descriptor_data *d, cJSON *data)
 
 	if (cmd && *cmd)
 	{
-		write_to_q(cmd, &d->input, 0);
+		write_to_input_q(d, cmd);
 	}
 }
 
@@ -3145,7 +3145,7 @@ void ws_handle_command(struct descriptor_data *d, const char *cmd, cJSON *data)
 		/* unknown = game cmd */
 		if (d->connected == CON_PLAYING)
 		{
-			write_to_q(cmd, &d->input, 0);
+			write_to_input_q(d, cmd);
 		}
 	}
 }

--- a/tests/async/telnet_input_runtime_harness.cpp
+++ b/tests/async/telnet_input_runtime_harness.cpp
@@ -1,0 +1,73 @@
+#include "config.h"
+#include "gmcp.h"
+#include "structs.h"
+#include "telnet.h"
+
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+P_desc descriptor_list = nullptr;
+long sentbytes = 0;
+
+static int gmcp_negotiations = 0;
+static int ttype_negotiations = 0;
+
+void * __malloc(size_t size, char *, char *, int) { return std::calloc(1, size); }
+void __free(void *ptr, char *, int) { std::free(ptr); }
+void panic_corruption_int(const char *, const char *, ...) { std::abort(); }
+void panic_corruption(const char *, const char *, ...) { std::abort(); }
+void logit(const char *, const char *, ...) {}
+
+void gmcp_handle_negotiation(P_desc, int) { ++gmcp_negotiations; }
+void gmcp_handle_input(P_desc, const char *, size_t) {}
+void ttype_handle_negotiation(P_desc, int) { ++ttype_negotiations; }
+void ttype_handle_subnegotiation(P_desc, const unsigned char *, int) {}
+int websocket_send_text(P_desc, const char *) { return 0; }
+char *json_escape_ansi_string(const char *) { return nullptr; }
+
+int parse_telnet_options(P_desc player, char *buf, int buflen);
+
+static void require(bool condition, const char *message)
+{
+	if (!condition)
+	{
+		std::fprintf(stderr, "FAIL: %s\n", message);
+		std::exit(1);
+	}
+}
+
+int main()
+{
+	descriptor_data descriptor{};
+
+	char one_byte[] = {static_cast<char>(IAC), 0};
+	require(parse_telnet_options(&descriptor, one_byte, 1) == 0,
+	        "single IAC byte must remain pending");
+
+	char two_byte_do[] = {static_cast<char>(IAC), static_cast<char>(DO), 0};
+	require(parse_telnet_options(&descriptor, two_byte_do, 2) == 0,
+	        "IAC DO without option byte must remain pending");
+	require(gmcp_negotiations == 0, "partial negotiation must have no side effects");
+
+	char complete_gmcp[] = {static_cast<char>(IAC), static_cast<char>(DO),
+	                        static_cast<char>(TELOPT_GMCP), 0};
+	require(parse_telnet_options(&descriptor, complete_gmcp, 3) == 3,
+	        "complete GMCP negotiation must consume three bytes");
+	require(gmcp_negotiations == 1, "complete GMCP negotiation must dispatch once");
+
+	char two_iac[] = {static_cast<char>(IAC), static_cast<char>(IAC), 0};
+	require(parse_telnet_options(&descriptor, two_iac, 2) == 2,
+	        "escaped IAC must consume both bytes");
+
+	char partial_subnegotiation[] = {static_cast<char>(IAC), static_cast<char>(SB),
+	                                 static_cast<char>(TELOPT_TTYPE), 0};
+	require(parse_telnet_options(&descriptor, partial_subnegotiation, 3) == 0,
+	        "unterminated subnegotiation must remain pending");
+	require(ttype_negotiations == 0, "partial subnegotiation must have no side effects");
+
+	std::puts("Telnet input runtime harness passed");
+	return 0;
+}

--- a/tests/async/test_telnet_input_contract.py
+++ b/tests/async/test_telnet_input_contract.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Source contracts for legacy Telnet input boundary hardening."""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+COMM = (ROOT / "src" / "comm.c").read_text()
+MCCP = (ROOT / "src" / "mccp.c").read_text()
+PROTOTYPES = (ROOT / "src" / "prototypes.h").read_text()
+
+
+def require(text: str, source: str, message: str) -> None:
+    if text not in source:
+        raise AssertionError(message)
+
+
+def test_telnet_parser_waits_for_complete_command() -> None:
+    require(
+        "if (buflen < 2)",
+        MCCP,
+        "Telnet parser must not read the command byte until IAC plus command are available",
+    )
+    require(
+        "buflen < 3 &&",
+        MCCP,
+        "Telnet parser must not read an option byte until IAC, command, and option are available",
+    )
+
+
+def test_process_input_preserves_partial_telnet_sequence() -> None:
+    require(
+        "memmove(bp, buf + i, (size_t)(len - i));",
+        COMM,
+        "process_input must retain a fragmented Telnet sequence for the next socket read",
+    )
+    require(
+        "bp += len - i;",
+        COMM,
+        "retained fragmented Telnet bytes must contribute to descriptor buflen",
+    )
+
+
+def test_queue_dequeue_is_destination_sized() -> None:
+    require(
+        "int get_from_q(struct txt_q *queue, char *dest, size_t dest_size)",
+        COMM,
+        "queue dequeue must receive the destination capacity",
+    )
+    if not re.search(r"int\s+get_from_q\(struct txt_q \*, char \*, size_t\);", PROTOTYPES):
+        raise AssertionError("public queue dequeue declaration must require destination capacity")
+    require(
+        "copy_len = std::min(text_len, dest_size - 1);",
+        COMM,
+        "queue dequeue must bound the copied text by destination capacity",
+    )
+
+
+if __name__ == "__main__":
+    test_telnet_parser_waits_for_complete_command()
+    test_process_input_preserves_partial_telnet_sequence()
+    test_queue_dequeue_is_destination_sized()
+    print("Telnet input hardening contracts passed")

--- a/tests/async/test_telnet_input_contract.py
+++ b/tests/async/test_telnet_input_contract.py
@@ -91,6 +91,13 @@ def test_account_confirmation_does_not_echo_stored_state() -> None:
         raise AssertionError("account confirmation must not echo stored authentication state")
 
 
+def test_descriptor_identity_copies_are_bounded() -> None:
+    if "strcpy(point->login, ident_ans_buf.name);" in COMM:
+        raise AssertionError("ident response must not overflow the descriptor login field")
+    require("strlcpy(point->login, ident_ans_buf.name, sizeof(point->login));", COMM,
+            "ident response copy must use destination capacity")
+
+
 if __name__ == "__main__":
     test_telnet_parser_waits_for_complete_command()
     test_process_input_preserves_partial_telnet_sequence()
@@ -98,4 +105,5 @@ if __name__ == "__main__":
     test_input_queue_is_bounded_and_accounted()
     test_pre_auth_terminal_selection_uses_full_input_capacity()
     test_account_confirmation_does_not_echo_stored_state()
+    test_descriptor_identity_copies_are_bounded()
     print("Telnet input hardening contracts passed")

--- a/tests/async/test_telnet_input_contract.py
+++ b/tests/async/test_telnet_input_contract.py
@@ -77,9 +77,18 @@ def test_input_queue_is_bounded_and_accounted() -> None:
             raise AssertionError(f"{relative} bypasses the bounded descriptor input queue")
 
 
+def test_pre_auth_terminal_selection_uses_full_input_capacity() -> None:
+    nanny = (ROOT / "src" / "nanny.c").read_text()
+    require("char temp_buf[MAX_INPUT_LENGTH];", nanny, "terminal parsing token buffer must match accepted input capacity")
+    if "strcpy(d->client_str, arg);" in nanny:
+        raise AssertionError("pre-auth terminal parsing must bound copies into client_str")
+    require("strlcpy(d->client_str, arg, sizeof(d->client_str));", nanny, "client identifier copies must be destination-sized")
+
+
 if __name__ == "__main__":
     test_telnet_parser_waits_for_complete_command()
     test_process_input_preserves_partial_telnet_sequence()
     test_queue_dequeue_is_destination_sized()
     test_input_queue_is_bounded_and_accounted()
+    test_pre_auth_terminal_selection_uses_full_input_capacity()
     print("Telnet input hardening contracts passed")

--- a/tests/async/test_telnet_input_contract.py
+++ b/tests/async/test_telnet_input_contract.py
@@ -85,10 +85,17 @@ def test_pre_auth_terminal_selection_uses_full_input_capacity() -> None:
     require("strlcpy(d->client_str, arg, sizeof(d->client_str));", nanny, "client identifier copies must be destination-sized")
 
 
+def test_account_confirmation_does_not_echo_stored_state() -> None:
+    account = (ROOT / "src" / "account.c").read_text()
+    if "DEBUG: Stored=" in account or "SEND_TO_Q(debug_buf, d);" in account:
+        raise AssertionError("account confirmation must not echo stored authentication state")
+
+
 if __name__ == "__main__":
     test_telnet_parser_waits_for_complete_command()
     test_process_input_preserves_partial_telnet_sequence()
     test_queue_dequeue_is_destination_sized()
     test_input_queue_is_bounded_and_accounted()
     test_pre_auth_terminal_selection_uses_full_input_capacity()
+    test_account_confirmation_does_not_echo_stored_state()
     print("Telnet input hardening contracts passed")

--- a/tests/async/test_telnet_input_contract.py
+++ b/tests/async/test_telnet_input_contract.py
@@ -56,8 +56,30 @@ def test_queue_dequeue_is_destination_sized() -> None:
     )
 
 
+def test_input_queue_is_bounded_and_accounted() -> None:
+    structs = (ROOT / "src" / "structs.h").read_text()
+    config = (ROOT / "src" / "config.h").read_text()
+    require("size_t            bytes;", structs, "text queues must account queued bytes")
+    require("size_t            blocks;", structs, "text queues must account queued entries")
+    require("MAX_INPUT_QUEUE_BYTES", config, "input queues need an explicit byte ceiling")
+    require("MAX_INPUT_QUEUE_COMMANDS", config, "input queues need an explicit command ceiling")
+    require("MAX_INPUT_LINES_PER_READ", config, "socket reads need a per-event line-work ceiling")
+    require("int write_to_input_q(P_desc d, const char *txt)", COMM, "descriptor input must use the bounded input queue API")
+    require("queue->bytes += txtlen;", COMM, "queue writes must update byte accounting")
+    require("queue->blocks++;", COMM, "queue writes must update entry accounting")
+    require("queue->bytes -= text_len;", COMM, "queue reads must release byte accounting")
+    require("queue->blocks--;", COMM, "queue reads must release entry accounting")
+    require("if (++lines_processed > MAX_INPUT_LINES_PER_READ)", COMM, "socket input must cap lines handled per read")
+    require("write_to_input_q(t, out)", COMM, "Telnet lines must use the bounded descriptor input queue")
+    for relative in ("src/websocket.c", "src/ws_handlers.c"):
+        source = (ROOT / relative).read_text()
+        if re.search(r"write_to_q\([^\n]*&d->input", source):
+            raise AssertionError(f"{relative} bypasses the bounded descriptor input queue")
+
+
 if __name__ == "__main__":
     test_telnet_parser_waits_for_complete_command()
     test_process_input_preserves_partial_telnet_sequence()
     test_queue_dequeue_is_destination_sized()
+    test_input_queue_is_bounded_and_accounted()
     print("Telnet input hardening contracts passed")


### PR DESCRIPTION
## Summary

Hardens the legacy Telnet/login descriptor input boundary while preserving normal command, login, GMCP, MCCP, and WebSocket command-routing behavior.

This branch is based directly on `Community-Duris/DurisMUD:master` at `c08def33`; it does not include the separate WebSocket hardening PR.

## Security and reliability changes

- Preserve fragmented Telnet IAC negotiation sequences across TCP reads instead of dropping partial protocol state.
- Require complete command/option bytes before Telnet negotiation parsing reads them.
- Make text queue dequeue destination-sized rather than using unbounded `strcpy()`.
- Track queue byte and block counts and enforce descriptor input limits:
  - 128 newline-delimited commands processed per socket read
  - 256 pending commands per descriptor
  - 65,536 pending input bytes per descriptor
- Route Telnet, WebSocket, and DurisWeb command producers through the same bounded descriptor input API.
- Warn once during an overflow episode and drop excess commands instead of allowing unbounded queue growth.
- Match pre-auth terminal token storage to the accepted input size, closing a reachable 1,024-byte-input-to-200-byte-stack-buffer mismatch.
- Bound copies into terminal client identity and descriptor ident fields.
- Remove production DEBUG output that echoed entered, normalized, and stored account confirmation values.

## Compatibility

- Normal Telnet command lines remain capped at the existing `MAX_INPUT_LENGTH` behavior.
- Existing command ordering and one-command-per-pulse dispatch are retained.
- Normal MCCP, GMCP, terminal-type, login, snooping, and WebSocket command producers retain their established routing.
- Legitimate command bursts remain supported within the documented queue limits.
- Overflow behavior is fail-bounded: excess commands are dropped with a one-time warning rather than consuming memory indefinitely.

## Commit structure

1. `fix(input): preserve fragmented Telnet state safely`
2. `fix(input): bound descriptor command queues`
3. `fix(login): size terminal negotiation buffers`
4. `fix(login): remove confirmation debug disclosure`
5. `test(input): cover fragmented Telnet negotiation`
6. `fix(input): bound descriptor ident copy`

## Verification

- [x] Production build: `cd src && make -f Makefile -j1`
- [x] Source contracts: `python tests/async/test_telnet_input_contract.py`
- [x] Python syntax compilation for the source contract
- [x] Runtime harness against the production Telnet parser
- [x] ASan/UBSan runtime harness
- [x] Warning-focused compilation of touched parser/input units
- [x] Focused cppcheck pass
- [x] `git diff --check`
- [x] Exact current upstream merge-base verification
- [x] Local/remote head SHA verification after push

Expected focused test output:

```text
Telnet input hardening contracts passed
Telnet input runtime harness passed
```

## Deliberate non-goals

- SQL query construction and escaping; handled in the next ordered hardening priority.
- Redis/world-state deserialization.
- Persistence worker ownership and shutdown.
- Shell/process execution.
- Character/object extraction invariants.
- A wholesale migration of every legacy command helper or string API without a proven source-to-sink defect.

## Review notes

The branch intentionally uses several small commits so protocol-state handling, queue/resource bounds, pre-auth buffer sizing, debug disclosure removal, and tests can be reviewed independently.
