### PR TITLE
MySQL/MariaDB issues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@
 # Load with: source .env (or use a wrapper script)
 
 # Database Configuration (fallback to defaults if not set)
-DB_HOST=127.0.0.1
+DB_HOST=localhost
 DB_USER=duris
 DB_PASSWD=duris
 DB_NAME=duris_dev

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ etc/group
 etc/passwd
 etc/resolv.conf
 migrate_pfiles
+duris-build-deps_1.0_*
 
 # Test binary artifacts
 tests/async/test_persistence

--- a/README.md
+++ b/README.md
@@ -235,12 +235,12 @@ Database connection settings are **hardcoded** in `src/sql.h` (lines 6-16):
 
 ```c
 #ifdef TEST_MUD
-  #define DB_HOST "127.0.0.1"
+  #define DB_HOST "localhost"
   #define DB_USER "duris"
   #define DB_PASSWD "duris"
   #define DB_NAME "duris_dev"
 #else
-  #define DB_HOST "127.0.0.1"
+  #define DB_HOST "localhost"
   #define DB_USER "duris"
   #define DB_PASSWD "duris"
   #define DB_NAME "duris"
@@ -368,13 +368,13 @@ MySQL initialization failed! Dying!
 3. **Wrong credentials:**
    ```bash
    # Test connection:
-   mysql -h127.0.0.1 -u duris -p duris_dev
+   mysql -hlocalhost -u duris -p duris_dev
    # Password: duris
    ```
 
 4. **User lacks privileges:**
    ```sql
-   GRANT ALL PRIVILEGES ON duris_dev.* TO 'duris'@'127.0.0.1' IDENTIFIED BY 'duris';
+   GRANT ALL PRIVILEGES ON duris_dev.* TO 'duris'@'localhost' IDENTIFIED BY 'duris';
    FLUSH PRIVILEGES;
    ```
 

--- a/README.md
+++ b/README.md
@@ -32,13 +32,15 @@ DurisMUD forked from Xanadinn's repo.
 **Ubuntu/Debian:**
 ```bash
 sudo apt-get update
-sudo apt-get install build-essential mysql-server libmysqlclient-dev
+sudo apt-get install build-essential
 sudo apt-get install libxml2 libxml2-dev
 sudo apt-get install zlib1g zlib1g-dev
 sudo apt-get install gnutls-dev
 sudo apt-get install libcjson-dev libssl-dev
 sudo apt-get install libhiredis-dev libbsd-dev
+sudo apt-get install default-libmysqlclient-dev default-mysql-server
 ```
+(MySQL has been replaced by MariaDB)
 
 **CentOS/RHEL:**
 ```bash

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ sudo yum install gcc make mysql-server mysql-devel
 sudo systemctl start mysql
 sudo systemctl enable mysql
 ```
+or
+```bash
+sudo service restart mysql
+```
 
 ### 2. Create Database and User
 
@@ -358,6 +362,10 @@ MySQL initialization failed! Dying!
    ```bash
    sudo systemctl status mysql
    sudo systemctl start mysql
+   ```
+   or, more universal:
+   ```
+   sudo service mysql restart
    ```
 
 2. **Database doesn't exist:**

--- a/duris-build-deps.equivs
+++ b/duris-build-deps.equivs
@@ -1,0 +1,22 @@
+# To compile: equivs-build duris-build-deps.equivs
+# To install: apt install ./duris-build-deps_1.0_all.deb
+Section: misc
+Priority: optional
+Homepage: https://www.newduris.com
+
+Package: duris-build-deps
+Maintainer: Adam Borowski <kilobyte@angband.pl>
+Depends: build-essential,
+	 libxml2-dev,
+	 zlib1g-dev,
+	 gnutls-dev,
+	 libcjson-dev,
+	 libssl-dev,
+	 libhiredis-dev,
+	 libbsd-dev,
+	 default-libmysqlclient-dev,
+	 default-mysql-server,
+Suggests: redis | redict,
+Description: build dependencies for Duris
+ This metapackage will install what you need for hacking on and running
+ a test instance of Duris.

--- a/import_help_to_prod.sh
+++ b/import_help_to_prod.sh
@@ -126,8 +126,8 @@ execute_sql() {
         # SSH mode: execute on remote server
         echo "$sql" | ssh "$REMOTE_USER@$REMOTE_HOST" "mysql -u$MYSQL_USER -p$MYSQL_PASS $MYSQL_DB"
     else
-        # Local mode: execute directly (use -h127.0.0.1 for containerized MySQL)
-        echo "$sql" | mysql -h127.0.0.1 -u$MYSQL_USER -p$MYSQL_PASS $MYSQL_DB
+        # Local mode: execute directly (use -hlocalhost for containerized MySQL)
+        echo "$sql" | mysql -hlocalhost -u$MYSQL_USER -p$MYSQL_PASS $MYSQL_DB
     fi
 }
 
@@ -140,8 +140,8 @@ execute_sql_file() {
         ssh "$REMOTE_USER@$REMOTE_HOST" "mysql -u$MYSQL_USER -p$MYSQL_PASS $MYSQL_DB < /tmp/import_sql.tmp"
         ssh "$REMOTE_USER@$REMOTE_HOST" "rm /tmp/import_sql.tmp"
     else
-        # Local mode: execute directly (use -h127.0.0.1 for containerized MySQL)
-        mysql -h127.0.0.1 -u$MYSQL_USER -p$MYSQL_PASS $MYSQL_DB < "$sqlfile"
+        # Local mode: execute directly (use -hlocalhost for containerized MySQL)
+        mysql -hlocalhost -u$MYSQL_USER -p$MYSQL_PASS $MYSQL_DB < "$sqlfile"
     fi
 }
 
@@ -154,7 +154,7 @@ if [ $USE_SSH -eq 1 ]; then
     echo "Remote Host: $REMOTE_HOST"
 else
     echo "Mode: LOCAL"
-    echo "Host: 127.0.0.1"
+    echo "Host: localhost"
 fi
 echo "Database: $MYSQL_DB"
 echo ""
@@ -496,9 +496,9 @@ VALUES ('{title.replace("'", "''")}', 0x{content_hex}, '{now}', 'Arih_importDB',
             capture_output=True, text=True
         )
     else:
-        # Local mode: execute directly (use -h127.0.0.1 for containerized MySQL)
+        # Local mode: execute directly (use -hlocalhost for containerized MySQL)
         mysql_result = subprocess.run(
-            ['mysql', '-h127.0.0.1', f'-u{MYSQL_USER}', f'-p{MYSQL_PASS}', MYSQL_DB],
+            ['mysql', '-hlocalhost', f'-u{MYSQL_USER}', f'-p{MYSQL_PASS}', MYSQL_DB],
             stdin=open('/tmp/import_help_entry.sql', 'r'),
             capture_output=True, text=True
         )
@@ -689,9 +689,9 @@ VALUES ('{safe_title}', 0x{content_hex}, '{now}', 'Arih_importDB', 0);"""
             capture_output=True, text=True
         )
     else:
-        # Local mode: execute directly (use -h127.0.0.1 for containerized MySQL)
+        # Local mode: execute directly (use -hlocalhost for containerized MySQL)
         mysql_result = subprocess.run(
-            ['mysql', '-h127.0.0.1', f'-u{MYSQL_USER}', f'-p{MYSQL_PASS}', MYSQL_DB],
+            ['mysql', '-hlocalhost', f'-u{MYSQL_USER}', f'-p{MYSQL_PASS}', MYSQL_DB],
             stdin=open('/tmp/import_help_entry.sql', 'r'),
             capture_output=True, text=True
         )

--- a/src/howto_sql_win.txt
+++ b/src/howto_sql_win.txt
@@ -1,8 +1,8 @@
-./mysqladmin create duris_dev -h127.0.0.1 --user=root -p
+./mysqladmin create duris_dev -hlocalhost --user=root -p
 
-./mysql -h127.0.0.1 --user=root -p
-mysql> GRANT ALL PRIVILEGES ON duris_dev.* TO duris@127.0.0.1 IDENTIFIED BY 'duris';
-./mysql -h127.0.0.1 --user=duris -pduris duris_dev < /cygdrive/d/eclwork/duris/SQL_CREATE_SCRIPT
+./mysql -hlocalhost --user=root -p
+mysql> GRANT ALL PRIVILEGES ON duris_dev.* TO duris@localhost IDENTIFIED BY 'duris';
+./mysql -hlocalhost --user=duris -pduris duris_dev < /cygdrive/d/eclwork/duris/SQL_CREATE_SCRIPT
 
 mysql> use duris_dev;
 mysql> show tables;

--- a/src/sql.c
+++ b/src/sql.c
@@ -412,10 +412,9 @@ int initialize_mysql()
   	mysql_options(DB, MYSQL_OPT_READ_TIMEOUT, &timeout);
   	mysql_options(DB, MYSQL_OPT_WRITE_TIMEOUT, &timeout);
 
-	DB = mysql_real_connect(DB, DB_HOST, DB_USER, DB_PASSWD, db_name, DB_PORT, NULL, CLIENT_MULTI_STATEMENTS);
-	if (DB == NULL)
+	if (!mysql_real_connect(DB, DB_HOST, DB_USER, DB_PASSWD, db_name, DB_PORT, NULL, CLIENT_MULTI_STATEMENTS))
 	{
-		logit(LOG_STATUS, "Error connecting to database.");
+		logit(LOG_STATUS, "Error connecting to database: %s", mysql_error(DB));
 		return -1;
 	}
 

--- a/src/sql.h
+++ b/src/sql.h
@@ -6,12 +6,12 @@
 
 /* default database credentials (fallback if env vars not set) */
 #ifdef TEST_MUD
-#define DB_HOST_DEFAULT   "127.0.0.1"
+#define DB_HOST_DEFAULT   "localhost"
 #define DB_USER_DEFAULT   "duris"
 #define DB_PASSWD_DEFAULT "duris"
 #define DB_NAME_DEFAULT   "duris_dev"
 #else
-#define DB_HOST_DEFAULT   "127.0.0.1"
+#define DB_HOST_DEFAULT   "localhost"
 #define DB_USER_DEFAULT   "duris"
 #define DB_PASSWD_DEFAULT "duris"
 #define DB_NAME_DEFAULT   "duris"
@@ -19,7 +19,7 @@
 
 #ifdef __CYGWIN_BUILD__
 #undef DB_HOST_DEFAULT
-#define DB_HOST_DEFAULT "127.0.0.1"
+#define DB_HOST_DEFAULT "localhost"
 #endif
 
 /* get database credentials from env vars with fallback */


### PR DESCRIPTION
MySQL has been replaced by MariaDB on Debian a long time ago because Oracle are doodoo-heads.  Debian does ship mysql connector, and it worked well enough with MariaDB until now.  The old insecure authentication has been dropped, breaking the mixed setup on current testing/unstable.

Thus:
 * document that you need matching server and connector
 * add an `equivs` metapackage for automating dependencies
 * show errors if connecting fails

Also:
 * allow the connector to try local pipe (before falling back to TCP/IP)