### PR TITLE
fix: correct bard sleep and molecular agitation bugs

### DIFF
--- a/src/bard.c
+++ b/src/bard.c
@@ -845,7 +845,7 @@ void bard_sleep(int l, P_char ch, P_char victim, int song)
 {
 	struct affected_type af;
 	P_obj                tmp_obj;
-	int                  i, level;
+	int                  i, level = l;
 
 	if (IS_TRUSTED(victim))
 		return;

--- a/src/psionics.c
+++ b/src/psionics.c
@@ -294,7 +294,7 @@ void spell_molecular_agitation(int level, P_char ch, char *arg, int type, P_char
 	                                   "The pain you're feeling is so intense you'd rather be dead. Ah, you are...",
 	                                   "$N suddenly doubles over due to what must be incredible pain. Only death can save $M. Wait, it did..."};
 
-	level = MIN(level, (sizeof(dam_each) / sizeof(dam_each[0] - 1)));
+	level = MIN(level, (sizeof(dam_each) / sizeof(dam_each[0])) - 1);
 	level = MAX(0, level);
 	dam   = number((dam_each[level] / 2), (dam_each[level] * 2));
 	if (StatSave(victim, APPLY_POW, POW_DIFF(ch, victim)))


### PR DESCRIPTION
## Summary

Fixes the two bugs documented in #4:

- Initializes `bard_sleep()`'s local `level` from its `l` parameter instead of using an uninitialized value.
- Corrects the `spell_molecular_agitation()` array-length expression so spell levels are clamped to the final valid `dam_each[]` index (`60`) rather than evaluating `sizeof(dam_each[0] - 1)`.

## Verification

- Focused RED source checks confirmed both original buggy expressions.
- Focused GREEN source checks confirmed both corrections.
- `git diff --check` passed.
- Full build passed:

```text
make -C src -f Makefile -j$(nproc)
```

The build produced and linked `src/dms_new` successfully.

## Scope

Only `src/bard.c` and `src/psionics.c` are changed.

Closes #4
