### PR TITLE
Fix sheared overhead map on non-square map zones

### DIFF
--- a/src/map.c
+++ b/src/map.c
@@ -228,7 +228,7 @@ unsigned int calculate_relative_room(unsigned int rroom, int x, int y)
 	local_y = ((vroom - zone_start_vnum) / zone->mapx) % zone->mapy;
 
 	// how far are we from the western local map edge
-	local_x = (vroom - zone_start_vnum) % zone->mapy;
+	local_x = (vroom - zone_start_vnum) % zone->mapx;
 
 	if (local_x + x < 0)
 		local_x += zone->mapx;

--- a/src/testcmd.c
+++ b/src/testcmd.c
@@ -64,7 +64,7 @@ void disproom(P_char ch, int x, int y)
 	local_y = ((vroom - zone_start_vnum) / zone->mapx) % zone->mapy;
 
 	// how far are we from the western local map edge
-	local_x = (vroom - zone_start_vnum) % zone->mapy;
+	local_x = (vroom - zone_start_vnum) % zone->mapx;
 
 	if (local_x + x < 0)
 	{
@@ -166,7 +166,7 @@ void do_test_room(P_char ch, char *arg, int cmd)
 	local_y = ((vroom - zone_start_vnum) / zone->mapx) % zone->mapy;
 
 	// how far are we from the western local map edge
-	local_x = (vroom - zone_start_vnum) % zone->mapy;
+	local_x = (vroom - zone_start_vnum) % zone->mapx;
 
 	char buff[100];
 	snprintf(buff, 100, "&+CZone:&n (%dx%d) [%d,%d] '%s'&n %s\n", zone->mapx, zone->mapy, local_x, local_y, zone->name, zone->filename);


### PR DESCRIPTION

On any map zone whose grid is not square, the overhead map a player sees is
sheared: every room past the first row draws in the wrong column, and each
row skews further than the last until the picture is unreadable. This PR is
a one-character fix that makes non-square map zones render correctly.
Square zones are unaffected before and after.

The bug: `calculate_relative_room()` derives the row of a room from its
offset with `/ zone->mapx` (map.c:228) but the column with `% zone->mapy`
(map.c:231). `mapx` is the row width, and the function itself says so
twice — the wrap tests clamp `local_x` against `zone->mapx` (map.c:233-236),
and the reconstruction at the end multiplies the row by `zone->mapx`
(map.c:243) — so the column must be `% zone->mapx` as well. On a square
grid `mapx == mapy` and the two expressions agree, which is why the bug
never shows there.

Worked example, a zone 21 wide by 13 high (`mapx=21`, `mapy=13`):

| room offset | actual position | column drawn (`% 13`) |
|---|---|---|
| 20 | row 0, col 20 | 7 |
| 21 | row 1, col 0 | 8 |
| 42 | row 2, col 0 | 3 |

Each row shears a further 21 mod 13 = 8 columns from the row above it.

Blast radius: only the renderers that call `calculate_relative_room()` —
the `map` command (map.c:658), ship maps (ship_utils.c:639), and
testcmd.c:220. Rooms, exits and movement never see the bad value.

Testing: built from a pristine `git archive` of this branch — exit 0,
224 objects, 280 warnings, and the warning set is identical to master
@ 2e4c95e8 (compared as a set, file + message with line numbers
normalised, not just counted).

Watched on a live boot, baseline vs fix — a 7x3 fixture map zone
(`mapx=7`, `mapy=3`, distinct landmark sectors), same database and
character on both binaries, `map 3` at the same true column (col 3) of
three consecutive rows. Baseline, exactly the modular arithmetic above —
the view slides one further column per row south:

    row 1 col 3:     row 0 col 3:     row 2 col 3:
    *M..+            .r*..            r....
    ^r..@            .*M..            *..@.
    r*..+            .^r..            M..+.

`@` is two cells right of centre in the first frame, one cell in the
third, and in the middle frame the player's own column has been sheared
clean out of his own map view — no `@` anywhere. The fix, same three
rooms — all three frames identical in shape, `@` dead centre, every
landmark at its authored (x,y):

    ..+..            ..+..            .....
    ..@..            ..@..            ..@..
    ..+..            .....            ..+..

On a square grid nothing moves, proven rather than assumed: on the
400x400 surface zone, `map` output from the fixed binary is
byte-identical to baseline — ANSI colour codes included — at two
windows and two radii. The branch also merges clean alongside the other
two branches prepared on this fork, and the merged build (same one-line
delta) drew the same unsheared frames on a live boot.

One nearby thing deliberately not touched: `do_test_room`
(testcmd.c:169) carries its own inline copy of the `% zone->mapy`
arithmetic in display-only diagnostics. Same pattern, no player-facing
effect — a follow-up nit rather than freight for a one-character fix.
