### PR TITLE
Fix zone_touch dedupe_key format string

### DIFF
--- a/src/sql.c
+++ b/src/sql.c
@@ -3703,7 +3703,7 @@ void sql_zone_touch_finished(const char *event_key, int boot_time,
 	         "toucher_pid, group_size, epic_value, alignment_delta, dedupe_key, created_at) "
 	         "VALUES ('zone_touch', '%s', %d, %d, %d, %d, %d, %d, %d, "
 	         "SHA2(CONCAT('zone_touch', '|', '%s', '|', %d, '|', %d, '|', %d, '|', "
-	         "%d, '|', %d, '|', %d, '|', %d, '|', %d), 256), NOW()) "
+	         "%d, '|', %d, '|', %d, '|', %d), 256), NOW()) "
 	         "ON DUPLICATE KEY UPDATE id=id",
 	         safe_key, boot_time, touched_at, zone_number,
 	         toucher_pid, group_size, epic_value, alignment_delta,
@@ -3725,7 +3725,7 @@ void sql_zone_touch_finished(const char *event_key, int boot_time,
 	    "toucher_pid, group_size, epic_value, alignment_delta, dedupe_key, created_at) "
 	    "VALUES ('zone_touch', '%s', %d, %d, %d, %d, %d, %d, %d, "
 	    "SHA2(CONCAT('zone_touch', '|', '%s', '|', %d, '|', %d, '|', %d, '|', "
-	    "%d, '|', %d, '|', %d, '|', %d, '|', %d), 256), NOW()) "
+	    "%d, '|', %d, '|', %d, '|', %d), 256), NOW()) "
 	    "ON DUPLICATE KEY UPDATE id=id",
 	    safe_key, boot_time, touched_at, zone_number,
 	    toucher_pid, group_size, epic_value, alignment_delta,


### PR DESCRIPTION

This makes the `dedupe_key` for zone_touch rows in
`persistence_scalar_events` a stable function of the event fields, so the
`ON DUPLICATE KEY` dedupe can actually do its job — and it removes one
warning from the stock build.

The bug: `sql_zone_touch_finished()` (sql.c:3701-3711) builds the key as
`SHA2(CONCAT('zone_touch', '|', '%s', '|', %d, ...), 256)` with one `%s`
and eight `%d`, but passes only seven ints after `safe_key`. The eighth
`%d` reads a vararg that was never passed — undefined behaviour — so the
hash mixes in an indeterminate value and the key is not reproducible.
The stock build already diagnoses it:

```
sql.c: In function ‘void sql_zone_touch_finished(const char*, int, int, int, int, int, int, int)’:
sql.c:3706:56: warning: format ‘%d’ expects a matching ‘int’ argument [-Wformat=]
```

The identical format string is repeated in the `qry()` retry just below
(sql.c:3722-3731) with the same defect; no warning fires there only
because `qry()` carries no format attribute.

The fix drops the surplus trailing `, '|', %d` from both call sites, so
the format matches the seven ints actually passed (boot_time, touched_at,
zone_number, toucher_pid, group_size, epic_value, alignment_delta).

One thing to weigh before merging, stated plainly: **this changes the
emitted hash.** Rows inserted before the fix will not dedupe against rows
inserted after it. Two things soften that: the old eighth field was an
indeterminate read, so the old keys were never stable dedupe keys to begin
with; and mixed old/new rows coexist harmlessly, since the DUPLICATE KEY
clause only fires on an exact key collision (worst case is one duplicate
pair across the boundary). Whether to clean or ignore the historical rows
is your call — the fix does not decide it for you.

Testing: built from a pristine `git archive` of this branch — exit 0,
224 objects, 279 warnings: the sql.c:3706 `-Wformat=` warning is gone and
the rest of the warning set is unchanged (compared as a set, not a count).

Also watched on live boots, both call sites, both binaries. One
discovery first, for honest weighing: `sql_zone_touch_finished()` has no
in-tree caller today (the epic-stone touch path INSERTs into
`zone_touches` directly), so this repairs dormant plumbing — nothing in
live play currently produces new rows through this path, which reframes
the migration question above: no old-format rows are being added while
you decide. The proof therefore drove the function by direct call during
full boots, identically on both trees, through both composition paths.
Baseline: the same canned call composed *different* SQL at the
`snprintf` site and the `qry()` site — eight integer fields for seven
arguments, the phantom eighth reading different stack slots (`0` at one
site; `1670001244` then `560140892` at the other, across two boots with
identical inputs) — and the database showed the consequence: rebooting
inserted a duplicate row instead of deduping (emitted keys `ff861142…`,
then `5bd27c49…`, same inputs). Fix: both sites compose byte-identical
statements across boots, a second boot inserts zero new rows (the
`ON DUPLICATE KEY` dedupe holds), and the emitted key
`d741b2d8a3f93b70…` matches an independent
`SELECT SHA2(CONCAT('zone_touch','|',…),256)` recompute of the seven
arguments in MariaDB — the key is now a pure function of its inputs.
Both captured statements execute clean against the real
`persistence_scalar_events` schema. The branch also merges clean
alongside the other two branches prepared on this fork; the combined
tip builds at 279 warnings and boots.

Possible follow-up, deliberately not in this PR: a
`__attribute__((format))` on `qry()` would have caught the second copy,
but it will surface every other latent format mismatch in the tree as new
warnings at once — that is its own conversation.
