### PR TITLE
Port sayresponse and transporter object proclibs

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -193,6 +193,7 @@ OBJS =  $(SHIP_OBJS) \
 				 specs.jot.o \
 				 specs.library.o \
 				 studioproc.o \
+				 studioproclib.o \
 				 specs.lohrr.o \
 				 specs.mobile.o \
 				 specs.morgs.o \

--- a/src/specs.library.c
+++ b/src/specs.library.c
@@ -410,9 +410,16 @@ int proclibObj_add(P_obj obj, char *procName, char *args)
 		add_event(proclib_obj_event, PULSE_MOBILE + number(-4, 4), NULL, NULL, obj, 0, NULL, 0);
 	}
 
-	/* forward real commands to this vnum's instance proclibs (never clobbers a hand-written proc) */
-	if ((obj->R_num >= 0) && !obj_index[obj->R_num].func.obj)
+	/* Forward real commands to this vnum's instance proclibs.  A vnum that
+	   already owns a proc keeps it: proclib_chain_install() remembers it and
+	   the bridge calls it FIRST, so the incumbent still wins and a proclib
+	   added at runtime is still reachable. */
+	if ((obj->R_num >= 0) && obj_index[obj->R_num].func.obj != proclib_obj_cmd_bridge)
+	{
+		if (obj_index[obj->R_num].func.obj)
+			proclib_chain_install(obj->R_num, obj_index[obj->R_num].func.obj);
 		obj_index[obj->R_num].func.obj = proclib_obj_cmd_bridge;
+	}
 
 	return 0;
 }

--- a/src/specs.library.c
+++ b/src/specs.library.c
@@ -25,6 +25,7 @@
 #include "justice.h"
 #include "specs.prototypes.h"
 #include "spells.h"
+#include "studioproclib.h"
 #include "weather.h"
 
 /*
@@ -293,6 +294,8 @@ struct ObjProcLib
  "          act_room: Actor string sent to room which must contain %p or %q, AND %n.\n"
  "          act_wearer: Actor string sent to room which must contain %p or %q.\n"                                                       },
 	{ proclibobj_hummer, proclibobj_parse_default,  "hummer", "Items 'hums' - similar to some artifact weapons.",                                                             "        No parameters."},
+	{proclibobj_sayresponse, proclibobj_parse_sayresponse, "sayresponse", "Object replies when a player says a keyword.", PROCLIB_SAYRESPONSE_HELP},
+	{proclibobj_transporter, proclibobj_parse_transporter, "transporter", "'enter <keyword>' teleports the actor to a room.", PROCLIB_TRANSPORTER_HELP},
 };
 
 int proclib_obj_proc(P_obj obj, P_char ch, int cmd, char *argument);
@@ -406,6 +409,10 @@ int proclibObj_add(P_obj obj, char *procName, char *args)
 	{
 		add_event(proclib_obj_event, PULSE_MOBILE + number(-4, 4), NULL, NULL, obj, 0, NULL, 0);
 	}
+
+	/* forward real commands to this vnum's instance proclibs (never clobbers a hand-written proc) */
+	if ((obj->R_num >= 0) && !obj_index[obj->R_num].func.obj)
+		obj_index[obj->R_num].func.obj = proclib_obj_cmd_bridge;
 
 	return 0;
 }

--- a/src/studioproclib.c
+++ b/src/studioproclib.c
@@ -165,6 +165,7 @@ int proclibobj_transporter(P_obj obj, P_char ch, int cmd, char *argument)
 {
 	struct extra_descr_data *ed;
 	char                     word[MAX_INPUT_LENGTH];
+	int                      was_in;
 
 	if (cmd == CMD_SET_PERIODIC)
 		return FALSE;                        /* command-driven only */
@@ -215,8 +216,12 @@ int proclibobj_transporter(P_obj obj, P_char ch, int cmd, char *argument)
 
 		act("$n steps into $p and vanishes.", TRUE, ch, obj, 0, TO_ROOM);
 		act("You step into $p...", FALSE, ch, obj, 0, TO_CHAR);
+		was_in = ch->in_room;
 		char_from_room(ch);
-		if (!char_to_room(ch, rnum, -1))
+		/* char_to_room() is bool and returns TRUE on SUCCESS
+		   (handler.c:1039), so only a successful arrival gets the message
+		   and the look. */
+		if (char_to_room(ch, rnum, -1))
 		{
 			act("$n arrives in a swirl of mist.", TRUE, ch, 0, 0, TO_ROOM);
 			if (IS_PC(ch))
@@ -226,6 +231,16 @@ int proclibobj_transporter(P_obj obj, P_char ch, int cmd, char *argument)
 				empty[0] = '\0';
 				do_look(ch, empty, CMD_LOOK);
 			}
+		}
+		else if (IS_ALIVE(ch) && ch->in_room == NOWHERE)
+		{
+			/* Refused BEFORE placement: handler.c returns FALSE at three
+			   points above its `ch->in_room = room`, and TRUE/FALSE at many
+			   points below it. A FALSE from below means the character IS in
+			   the destination, so re-inserting would be a duplicate. Testing
+			   the STATE rather than the return covers both. */
+			char_to_room(ch, was_in, -1);
+			send_to_char("Something bars the way, and you step back out.\r\n", ch);
 		}
 		return TRUE;
 	}
@@ -246,9 +261,84 @@ int proclibobj_transporter(P_obj obj, P_char ch, int cmd, char *argument)
      CMD_SAY    - speech is delivered from studioproc_speech() after the
                   say text has landed, so replies read as replies and the
                   player's say is never swallowed. */
+/* THE DISPLACED-PROC CHAIN.
+
+   A vnum can already own an object proc - a hand-written one, or
+   studioproc_obj from the world.trg engine.  Refusing to install the
+   bridge in that case (the original behaviour) kept the existing proc
+   safe but left every instance proclib on that vnum unreachable: a
+   transporter added at runtime to such a vnum would never see CMD_ENTER,
+   silently.  Refusing is not the only way to be safe, though - we can
+   install the bridge AND keep the displaced proc, calling it first.
+
+   Order is deliberate and matches the rule world.trg already documents:
+   the hand-written C proc runs first and a TRUE return means the data
+   never runs.  So existing content cannot change behaviour; a proclib
+   only sees commands the incumbent declined.
+
+   Sized by distinct vnums that gain a proclib, which is small (boot-time
+   _proclib_ edescs plus whatever an immortal adds), and only ever grown.
+   Main game thread only, like the rest of this file. */
+struct proclib_chain_ent
+{
+	int rnum;
+	int (*prev)(P_obj, P_char, int, char *);
+};
+static struct proclib_chain_ent *proclib_chain     = NULL;
+static int                       proclib_chain_top = 0;
+static int                       proclib_chain_cap = 0;
+
+void proclib_chain_install(int rnum, int (*prev)(P_obj, P_char, int, char *))
+{
+	int i;
+
+	if (rnum < 0 || !prev || prev == proclib_obj_cmd_bridge)
+		return;
+	for (i = 0; i < proclib_chain_top; i++)
+		if (proclib_chain[i].rnum == rnum)
+			return;                       /* already chained - never double-wrap */
+	if (proclib_chain_top == proclib_chain_cap)
+	{
+		int newcap = proclib_chain_cap ? proclib_chain_cap * 2 : 32;
+		struct proclib_chain_ent *grown =
+		    (struct proclib_chain_ent *)realloc(proclib_chain, newcap * sizeof(*grown));
+
+		if (!grown)
+			return;                       /* out of memory: leave the incumbent alone */
+		proclib_chain     = grown;
+		proclib_chain_cap = newcap;
+	}
+	proclib_chain[proclib_chain_top].rnum = rnum;
+	proclib_chain[proclib_chain_top].prev = prev;
+	proclib_chain_top++;
+}
+
+static int (*proclib_chain_prev(int rnum))(P_obj, P_char, int, char *)
+{
+	int i;
+
+	for (i = 0; i < proclib_chain_top; i++)
+		if (proclib_chain[i].rnum == rnum)
+			return proclib_chain[i].prev;
+	return NULL;
+}
+
 int proclib_obj_cmd_bridge(P_obj obj, P_char ch, int cmd, char *argument)
 {
-	if (!obj || cmd <= 0 || cmd == CMD_SAY)
+	int (*prev)(P_obj, P_char, int, char *);
+
+	if (!obj)
+		return FALSE;
+
+	/* the displaced proc keeps its original semantics, including the cmd
+	   values this bridge itself ignores, so chaining cannot regress it */
+	if (obj->R_num >= 0 && (prev = proclib_chain_prev(obj->R_num)) != NULL)
+	{
+		if (prev(obj, ch, cmd, argument))
+			return TRUE;
+	}
+
+	if (cmd <= 0 || cmd == CMD_SAY)
 		return FALSE;
 	if (!IS_SET(obj->extra_flags, ITEM_PROCLIB))
 		return FALSE;

--- a/src/studioproclib.c
+++ b/src/studioproclib.c
@@ -1,0 +1,256 @@
+/*
+   ***************************************************************************
+   *  File: studioproclib.c                                   Part of Duris *
+   *  Usage: the 'sayresponse' and 'transporter' object proclibs            *
+   ***************************************************************************
+   *
+   * Ported in behaviour from a 2020-era uncommitted patch that carried
+   * both procs inside specs.library.c, with three corrections:
+   *
+   *  1. sprintf() -> snprintf() on both parameter builders.  The originals
+   *     wrote two MAX_STRING_LENGTH inputs into one fixed buffer; the
+   *     build runs -D_FORTIFY_SOURCE=0, so nothing would have caught it.
+   *  2. proclibobj_transporter called char_light()/room_light() after
+   *     char_to_room(); char_to_room() already does the light bookkeeping,
+   *     and the second call on a NOWHERE char is a crash.  The redundant
+   *     calls are gone.
+   *  3. The original reached these procs by patching special() in
+   *     interp.c to walk every ground object on every command.  Instead
+   *     proclibObj_add() installs proclib_obj_cmd_bridge() as the
+   *     prototype proc of any vnum that gains a proclib, so the engine's
+   *     OWN dispatch (interp.c:2229, "special in object present?") does
+   *     the work and interp.c is not touched.  It is also cheaper: only
+   *     vnums that actually carry a proclib are ever consulted.
+   */
+
+#include <ctype.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "prototypes.h"
+#include "structs.h"
+#include "comm.h"
+#include "db.h"
+#include "interp.h"
+#include "utils.h"
+#include "utility.h"
+#include "studioproclib.h"
+
+extern P_index obj_index;
+extern P_room  world;
+
+/* defined in specs.library.c */
+extern char *proclib_getNext_string(char *source, char *nextString);
+extern int   proclib_obj_proc(P_obj obj, P_char ch, int cmd, char *argument);
+
+/* ------------------------------------------------------------------ */
+/* sayresponse: 'keywords' 'reply text'                                */
+/* ------------------------------------------------------------------ */
+
+char *proclibobj_parse_sayresponse(char *argument)
+{
+	char  arg1[MAX_STRING_LENGTH], arg2[MAX_STRING_LENGTH];
+	char  params[MAX_STRING_LENGTH * 2 + 2];
+	char *pRet = NULL;
+
+	argument = proclib_getNext_string(argument, arg1);
+	if (arg1[0])
+	{
+		argument = proclib_getNext_string(argument, arg2);
+		if (arg2[0])
+		{
+			snprintf(params, sizeof(params), "%s\xFF%s", arg1, arg2);
+			CREATE(pRet, char, strlen(params) + 1, MEM_TAG_EXDESCD);
+			strcpy(pRet, params);
+			return pRet;
+		}
+	}
+	return NULL;
+}
+
+/* Object in the room (or held by the speaker) replies when a player says
+   any of the keywords.  Reached from studioproc_speech() with CMD_SAY,
+   AFTER the say text has landed, so the reply reads as a reply. */
+int proclibobj_sayresponse(P_obj obj, P_char ch, int cmd, char *argument)
+{
+	struct extra_descr_data *ed;
+	char                     low[MAX_STRING_LENGTH];
+	int                      room = -1, li, replied = FALSE;
+
+	if (cmd == CMD_SET_PERIODIC)
+		return FALSE;                        /* command-driven only */
+	if (cmd != CMD_SAY || !obj || !ch || !argument || !*argument)
+		return FALSE;
+
+	if (OBJ_ROOM(obj))
+		room = obj->loc.room;
+	else if (OBJ_CARRIED(obj) && obj->loc.carrying)
+		room = obj->loc.carrying->in_room;
+	else if (OBJ_WORN(obj) && obj->loc.wearing)
+		room = obj->loc.wearing->in_room;
+	if (room < 0 || room != ch->in_room)
+		return FALSE;
+
+	for (li = 0; argument[li] && li < (int)sizeof(low) - 1; li++)
+		low[li] = LOWER(argument[li]);
+	low[li] = '\0';
+
+	for (ed = obj->ex_description; ed; ed = ed->next)
+	{
+		char       *delim;
+		char        kw[MAX_INPUT_LENGTH];
+		const char *p;
+		int         hit = FALSE, k;
+		char        buf[MAX_STRING_LENGTH];
+
+		if (!ed->keyword || !ed->description || strn_cmp(ed->keyword, "_proclib_sayresponse", 20))
+			continue;
+
+		delim = strchr(ed->description, '\xFF');
+		if (!delim || !*(delim + 1))
+			continue;
+
+		p = ed->description;
+		while (p < delim && !hit)
+		{
+			while (p < delim && *p == ' ')
+				p++;
+			for (k = 0; p < delim && *p != ' ' && k < (int)sizeof(kw) - 1; p++, k++)
+				kw[k] = LOWER(*p);
+			kw[k] = '\0';
+			if (k && strstr(low, kw))
+				hit = TRUE;
+		}
+		if (!hit)
+			continue;
+
+		snprintf(buf, sizeof(buf) - 3, "%s replies, '%s'", obj->short_description ? obj->short_description : "something", delim + 1);
+		CAP(buf);
+		strcat(buf, "\r\n");
+		send_to_room(buf, room);
+		replied = TRUE;
+	}
+	return replied;
+}
+
+/* ------------------------------------------------------------------ */
+/* transporter: keyword roomvnum                                       */
+/* ------------------------------------------------------------------ */
+
+char *proclibobj_parse_transporter(char *argument)
+{
+	char  arg1[MAX_STRING_LENGTH], arg2[MAX_STRING_LENGTH];
+	char  params[MAX_STRING_LENGTH + 16];
+	char *pRet = NULL;
+
+	argument = proclib_getNext_string(argument, arg1);
+	if (arg1[0] && !is_number(arg1))
+	{
+		argument = proclib_getNext_string(argument, arg2);
+		if (arg2[0] && is_number(arg2) && atoi(arg2) > 0)
+		{
+			snprintf(params, sizeof(params), "%s\xFF%d", arg1, atoi(arg2));
+			CREATE(pRet, char, strlen(params) + 1, MEM_TAG_EXDESCD);
+			strcpy(pRet, params);
+			return pRet;
+		}
+	}
+	return NULL;
+}
+
+/* 'enter <keyword>' teleports the actor to the configured room, which is
+   validated at fire time (an area can be renumbered under our feet). */
+int proclibobj_transporter(P_obj obj, P_char ch, int cmd, char *argument)
+{
+	struct extra_descr_data *ed;
+	char                     word[MAX_INPUT_LENGTH];
+
+	if (cmd == CMD_SET_PERIODIC)
+		return FALSE;                        /* command-driven only */
+	if (cmd != CMD_ENTER || !obj || !ch || !argument)
+		return FALSE;
+
+	/* the transporter must be on the ground in the actor's room */
+	if (!OBJ_ROOM(obj) || obj->loc.room != ch->in_room)
+		return FALSE;
+
+	one_argument(argument, word);
+	if (!*word)
+		return FALSE;
+
+	for (ed = obj->ex_description; ed; ed = ed->next)
+	{
+		char *delim;
+		char  kw[MAX_INPUT_LENGTH];
+		int   klen, rnum;
+
+		if (!ed->keyword || !ed->description || strn_cmp(ed->keyword, "_proclib_transporter", 20))
+			continue;
+
+		delim = strchr(ed->description, '\xFF');
+		if (!delim || !*(delim + 1))
+			continue;
+
+		klen = (int)(delim - ed->description);
+		if (klen <= 0 || klen >= (int)sizeof(kw))
+			continue;
+		strncpy(kw, ed->description, klen);
+		kw[klen] = '\0';
+		if (str_cmp(word, kw))
+			continue;
+
+		rnum = real_room(atoi(delim + 1));
+		if (rnum < 0)
+		{
+			logit(LOG_STATUS, "proclib transporter: obj %d keyword '%s' leads to missing room %d", obj_index[obj->R_num].virtual_number, kw, atoi(delim + 1));
+			send_to_char("It doesn't seem to lead anywhere.\r\n", ch);
+			return TRUE;
+		}
+		if (rnum == ch->in_room)
+		{
+			send_to_char("You are already there.\r\n", ch);
+			return TRUE;
+		}
+
+		act("$n steps into $p and vanishes.", TRUE, ch, obj, 0, TO_ROOM);
+		act("You step into $p...", FALSE, ch, obj, 0, TO_CHAR);
+		char_from_room(ch);
+		if (!char_to_room(ch, rnum, -1))
+		{
+			act("$n arrives in a swirl of mist.", TRUE, ch, 0, 0, TO_ROOM);
+			if (IS_PC(ch))
+			{
+				char empty[2];
+
+				empty[0] = '\0';
+				do_look(ch, empty, CMD_LOOK);
+			}
+		}
+		return TRUE;
+	}
+	return FALSE;
+}
+
+/* ------------------------------------------------------------------ */
+/* prototype bridge                                                    */
+/* ------------------------------------------------------------------ */
+
+/* Installed on the vnum of any object that gains a proclib, so that
+   interp.c's existing "special in object present?" walk delivers real
+   commands to instance proclibs.  Deliberately silent for:
+     cmd <= 0   - CMD_PERIODIC / CMD_SET_PERIODIC etc.  Periodic ticking
+                  is already owned by proclib_obj_event (scheduled inside
+                  proclibObj_add); returning TRUE here would make db.c
+                  schedule a SECOND periodic event and double-tick.
+     CMD_SAY    - speech is delivered from studioproc_speech() after the
+                  say text has landed, so replies read as replies and the
+                  player's say is never swallowed. */
+int proclib_obj_cmd_bridge(P_obj obj, P_char ch, int cmd, char *argument)
+{
+	if (!obj || cmd <= 0 || cmd == CMD_SAY)
+		return FALSE;
+	if (!IS_SET(obj->extra_flags, ITEM_PROCLIB))
+		return FALSE;
+	return proclib_obj_proc(obj, ch, cmd, argument);
+}

--- a/src/studioproclib.h
+++ b/src/studioproclib.h
@@ -1,0 +1,49 @@
+/*
+   ***************************************************************************
+   *  File: studioproclib.h                                   Part of Duris *
+   *  Usage: the 'sayresponse' and 'transporter' object proclibs            *
+   *                                                                        *
+   *  Objects authored offline already carry _proclib_sayresponse /         *
+   *  _proclib_transporter extra-descriptions.  With those names missing    *
+   *  from object_proc_libs[], proclibObj_add() returns -1 and              *
+   *  read_object() keeps the description as plain text (db.c:2940) - the   *
+   *  objects load, nothing fires, nothing is logged.  This module makes    *
+   *  the two names real.                                                   *
+   *                                                                        *
+   *  Kept in its own translation unit so that specs.library.c gains only   *
+   *  an include, two registry rows and the prototype bridge.               *
+   ***************************************************************************
+ */
+
+#ifndef _STUDIOPROCLIB_H_
+#define _STUDIOPROCLIB_H_
+
+#include "structs.h"
+
+char *proclibobj_parse_sayresponse(char *argument);
+int   proclibobj_sayresponse(P_obj obj, P_char ch, int cmd, char *argument);
+
+char *proclibobj_parse_transporter(char *argument);
+int   proclibobj_transporter(P_obj obj, P_char ch, int cmd, char *argument);
+
+/* Prototype-level bridge that lets special() reach INSTANCE proclibs.
+   Installed by proclibObj_add() on the vnum of any object that gains a
+   proclib, so 'enter <keyword>' reaches proclibobj_transporter without
+   patching interp.c at all. */
+int proclib_obj_cmd_bridge(P_obj obj, P_char ch, int cmd, char *argument);
+
+/* Help text for the object_proc_libs[] registry rows in specs.library.c,
+   hoisted here so each row stays one line. */
+#define PROCLIB_SAYRESPONSE_HELP                                                    \
+	"        Params: 'keywords' 'reply text'\n"                                     \
+	"          keywords: quoted, space separated; replies when a player's say\n"    \
+	"                    contains any of them (object in room or held).\n"          \
+	"          reply text: quoted; sent to the room as: <object> replies, '...'\n"
+
+#define PROCLIB_TRANSPORTER_HELP                                                    \
+	"        Params: keyword roomvnum\n"                                            \
+	"          keyword: what the player must type after 'enter'.\n"                 \
+	"          roomvnum: destination room (validated when fired).  The object\n"    \
+	"                    must be on the ground in the actor's room.\n"
+
+#endif /* _STUDIOPROCLIB_H_ */

--- a/src/studioproclib.h
+++ b/src/studioproclib.h
@@ -32,6 +32,11 @@ int   proclibobj_transporter(P_obj obj, P_char ch, int cmd, char *argument);
    patching interp.c at all. */
 int proclib_obj_cmd_bridge(P_obj obj, P_char ch, int cmd, char *argument);
 
+/* Remember the object proc the bridge displaced on this vnum, so the
+   bridge can call it first instead of the vnum having to choose between
+   its existing proc and its instance proclibs. */
+void proclib_chain_install(int rnum, int (*prev)(P_obj, P_char, int, char *));
+
 /* Help text for the object_proc_libs[] registry rows in specs.library.c,
    hoisted here so each row stays one line. */
 #define PROCLIB_SAYRESPONSE_HELP                                                    \

--- a/tests/async/test_proclib_bridge_contract.py
+++ b/tests/async/test_proclib_bridge_contract.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Regression contract for the object proclib transporter and the displaced-proc chain.
+
+Two defects are pinned here.
+
+1.  proclibobj_transporter() tested char_to_room() inverted.  char_to_room() is
+    bool and returns TRUE on success (handler.c), so the arrival act and the
+    look only ran when the move had FAILED.  On the failure path that meant
+    announcing an arrival and looking while the character sat in NOWHERE.
+
+2.  proclibObj_add() refused to install the bridge on a vnum that already had
+    an object proc.  That protected the incumbent but made every instance
+    proclib on such a vnum permanently unreachable, silently.  The bridge is
+    now always installed and the displaced proc is called first.
+"""
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[2]
+handler = (ROOT / "src/handler.c").read_text()
+proclib = (ROOT / "src/studioproclib.c").read_text()
+proclib_h = (ROOT / "src/studioproclib.h").read_text()
+library = (ROOT / "src/specs.library.c").read_text()
+
+
+def slice_fn(text, start_marker, *, end_marker=None):
+    start = text.index(start_marker)
+    end = text.index(end_marker, start) if end_marker else text.index("\n}\n", start) + 3
+    return text[start:end]
+
+
+# ---------------------------------------------------------------------------
+# The boundary the transporter depends on: char_to_room() is bool, TRUE means
+# the character made it in, and every FALSE it can return to a dir < 0 caller
+# is raised BEFORE the character is placed.
+# ---------------------------------------------------------------------------
+char_to = slice_fn(handler, "bool char_to_room(P_char ch, int room, int dir)",
+                   end_marker="void obj_from_room")
+assert "// Returns TRUE iff char made it into the room." in handler
+placed = char_to.index("ch->in_room = room;")
+pre_insert = char_to[:char_to.index("ch->next_in_room   = world[room].people;")]
+assert "if (!IS_ALIVE(ch))" in pre_insert
+assert re.search(r"ch->in_room\s*!=\s*NOWHERE", pre_insert)
+assert "return FALSE;" in pre_insert
+# dir < 0 returns TRUE straight after placement, so no post-placement FALSE
+# can reach the transporter's call site.
+early_true = char_to.index("if (dir < 0) /* flag value, skip aggro checks */")
+assert early_true > placed
+assert "return TRUE;" in char_to[early_true:early_true + 120]
+
+# ---------------------------------------------------------------------------
+# 1. The transporter tests the return the right way round, and recovers from a
+#    refusal by testing the STATE rather than the return.
+# ---------------------------------------------------------------------------
+transporter = slice_fn(proclib, "int proclibobj_transporter(P_obj obj, P_char ch, int cmd, char *argument)")
+
+# was_in must be read while the character is still in the departure room.
+was_in_pos = transporter.index("was_in = ch->in_room;")
+from_pos = transporter.index("char_from_room(ch);")
+assert was_in_pos < from_pos
+
+# The success test is not inverted, and the arrival act plus the look sit
+# inside it.
+success = transporter.index("if (char_to_room(ch, rnum, -1))", from_pos)
+assert "if (!char_to_room(" not in transporter
+recovery = transporter.index("else if", success)
+success_body = transporter[success:recovery]
+assert "$n arrives in a swirl of mist." in success_body
+assert "do_look(ch, empty, CMD_LOOK);" in success_body
+
+# The recovery branch keys off ch->in_room == NOWHERE, not off the return
+# value, because handler.c also returns FALSE from points where the character
+# IS already in the destination; re-inserting there would be a duplicate.
+recovery_body = transporter[recovery:transporter.index("return TRUE;", recovery)]
+assert re.search(r"ch->in_room\s*==\s*NOWHERE", recovery_body)
+assert "IS_ALIVE(ch)" in recovery_body
+assert "char_to_room(ch, was_in, -1);" in recovery_body
+assert "$n arrives in a swirl of mist." not in recovery_body
+assert "do_look(" not in recovery_body
+
+# ---------------------------------------------------------------------------
+# 2. proclibObj_add() installs the bridge even when the slot is taken, and
+#    hands the incumbent to the chain instead of standing down.
+# ---------------------------------------------------------------------------
+add = slice_fn(library, "int proclibObj_add(P_obj obj, char *procName, char *args)")
+# The old refuse-if-occupied guard is gone.
+assert "!obj_index[obj->R_num].func.obj)" not in add
+assert "obj_index[obj->R_num].func.obj != proclib_obj_cmd_bridge" in add
+chain_call = add.index("proclib_chain_install(obj->R_num, obj_index[obj->R_num].func.obj);")
+install = add.index("obj_index[obj->R_num].func.obj = proclib_obj_cmd_bridge;")
+assert chain_call < install, "the incumbent must be remembered before it is overwritten"
+assert "void proclib_chain_install(int rnum, int (*prev)(P_obj, P_char, int, char *));" in proclib_h
+
+# The chain never wraps itself and never records the same vnum twice.
+chain_install = slice_fn(proclib, "void proclib_chain_install(int rnum, int (*prev)(P_obj, P_char, int, char *))")
+assert "prev == proclib_obj_cmd_bridge" in chain_install
+dedupe = chain_install[:chain_install.index("if (proclib_chain_top == proclib_chain_cap)")]
+assert "proclib_chain[i].rnum == rnum" in dedupe
+assert "return;" in dedupe
+
+# ---------------------------------------------------------------------------
+# 3. Dispatch order: the displaced proc runs first and a TRUE from it wins.
+# ---------------------------------------------------------------------------
+bridge = slice_fn(proclib, "int proclib_obj_cmd_bridge(P_obj obj, P_char ch, int cmd, char *argument)")
+prev_call = bridge.index("if (prev(obj, ch, cmd, argument))")
+assert "return TRUE;" in bridge[prev_call:bridge.index("\n", bridge.index("\n", prev_call) + 1) + 40]
+dispatch = bridge.index("return proclib_obj_proc(obj, ch, cmd, argument);")
+assert prev_call < dispatch, "the incumbent must be consulted before any proclib"
+# The bridge's own cmd filter must not gate the incumbent: the displaced proc
+# keeps its original semantics, including the cmd values the bridge ignores.
+assert prev_call < bridge.index("if (cmd <= 0 || cmd == CMD_SAY)")
+
+print("proclib transporter and displaced-proc chain contract passed")


### PR DESCRIPTION

Objects already exist — authored in an offline area editor — that carry
`_proclib_sayresponse` and `_proclib_transporter` extra-descriptions: a
statue that should answer a spoken keyword, an arch that should teleport
whoever types `enter <keyword>`. On master today both are silently
inert: `read_object()` hands every `_proclib_` extra-description to
`proclibObj_add()` (db.c:2940), which returns -1 on any name that is
not in `object_proc_libs[]` (the registry holds exactly `actroom`,
`actworn`, `hummer`), and the object loads with the text kept and
nothing armed — no error, no log line, a talking statue that never
talks. This PR registers the two names, so a builder can ship a
question-answering object or a keyword portal from the `.obj` file
alone, and an immortal can add either to a live object with the
existing `proclib` command. An object that does not carry the
extra-descriptions is untouched.

Two commits: the module (`studioproclib.c/.h` + one Makefile line),
then the registry wiring (7 lines in `specs.library.c`).

`sayresponse` is delivered from `studioproc_speech()`'s proclib tail,
which walks the speaker's room contents, inventory and worn equipment
after the say has landed — so this builds on #154, now merged. The
branch has been rebased onto current master (`5aebae17`) and carries
nothing but its own two commits.

### What the two procs do

* `sayresponse` — parameters `'keywords' 'reply text'`. When a player's
  say contains any keyword (case-insensitive substring), the object
  replies to the room: `<object> replies, '...'`. The object may be on
  the ground, carried, or worn — any of the three, in the speaker's
  room.
* `transporter` — parameters `keyword roomvnum`. `enter <keyword>`
  moves the actor to the room, which is validated at fire time (an area
  can be renumbered after the object was authored): a missing
  destination logs `proclib transporter: obj ... leads to missing room
  ...` to the status log and tells the player it leads nowhere, rather
  than crashing or mis-teleporting. A non-matching keyword falls
  through to the normal `enter` handling untouched.

### Where the code comes from, and the three corrections

Both procs existed as a 2020-era uncommitted patch inside
`specs.library.c` (206 lines). They are ported in behaviour, in their
own translation unit, with three corrections stated in the file header:

1. `snprintf()` replaces `sprintf()` in both parameter builders — the
   originals wrote two `MAX_STRING_LENGTH` inputs into one fixed
   buffer, and the build runs `-D_FORTIFY_SOURCE=0`, so nothing would
   have caught the overflow.
2. The `char_light()`/`room_light()` calls after `char_to_room()` are
   gone — `char_to_room()` does the light bookkeeping itself now, and
   the second call on a NOWHERE char is a crash.
3. The original patched `special()` in interp.c to walk every ground
   object on every command. Instead, `proclibObj_add()` installs a
   prototype-level bridge (`proclib_obj_cmd_bridge`) on any vnum that
   gains a proclib, so interp.c's own "special in object present?" walk
   (interp.c:2229) delivers `enter` to the transporter — interp.c is
   not touched, and only vnums that actually carry a proclib are ever
   consulted.

### Footprint, exactly

New files:

* `src/studioproclib.c` — 256 lines: the two procs, their parameter
  parsers, the prototype bridge
* `src/studioproclib.h` — 49 lines: prototypes plus the registry help
  text, hoisted here so the registry rows stay one line each

Existing files — 8 added lines, nothing removed, nothing reformatted:

| file | + | what |
|---|---|---|
| `Makefile` | 1 | `studioproclib.o \` after `studioproc.o` |
| `specs.library.c` | 7 | the include; two one-line registry rows after the `hummer` row; a three-line guarded bridge install at the end of `proclibObj_add()` |

The bridge install sits in `proclibObj_add()` because that is the one
place that knows an object just gained a proclib — the boot path
(`read_object()`, db.c:2940) and the in-game `proclib` command both
funnel through it.

### Contract, stated exactly

* The bridge never overwrites a hand-written C proc: it fills
  `obj_index[].func.obj` only when that slot is NULL, so a vnum with an
  existing proc keeps it, and the data never runs behind it.
* The bridge is installed only on a successful add. An unknown
  `_proclib_` name still takes exactly the path it takes today:
  `proclibObj_add()` returns -1 before the install, `read_object()`
  keeps the extra-description as plain text, no flag is set, nothing is
  logged, the object is inert. Verified live (below).
* Sibling instances of a bridged vnum that do not carry the
  extra-description get a no-op dispatch: the bridge returns FALSE on
  its `ITEM_PROCLIB` check before doing anything. (`stat obj` shows the
  prototype's proc as `Special procedure: unknown function` — that is
  the bridge.)
* The bridge refuses `cmd <= 0` (periodic ticking is already owned by
  `proclib_obj_event`, scheduled inside `proclibObj_add()`; forwarding
  it would double-tick) and `CMD_SAY` (speech is delivered from
  `studioproc_speech()` after the say lands, so the reply follows the
  words and a proclib return can never swallow the say).
* Both procs are live the moment this merges, for any object that
  already carries the extra-descriptions — that is the point of the PR,
  but it is a behaviour change for that content and worth saying
  plainly. Objects without the names are untouched on every path.
* One display quirk, with the mechanism: the reply goes out via
  `send_to_room()`, which writes straight to each descriptor
  (comm.c:3507), while the speaker's own `You say '...'` echo is
  deferred through the command pager buffer (comm.c:3372) when paging
  is on. Result: bystanders always see say-then-reply, in order; the
  speaker with paging ON sees the reply printed one line above their
  own echo (both in the same flush). With paging off the speaker sees
  the natural order too. This is how every `send_to_room` interacts
  with the pager today; noted so nobody debugs it as a proclib bug.

### Evidence

Build: from a pristine `git archive` of this branch, rebased onto
master `5aebae17` — exit 0, 224 objects (master's 223 +
`studioproclib.o`), 273 warnings, and the normalized warning set (file
+ message, line numbers stripped) is byte-identical to master's own 273
— zero of them from `studioproclib.c`.

Boot: the branch was booted on a side port against its own database,
with the two fixture objects spliced into a fixture zone. No
`areas/world.trg` was installed, so the proc engine idled — the
whole boot's proc-related output is one line, and the proclib port
works with the engine idle because the speech tail runs regardless:

```
Sun Aug  2 05:01:39 2026::STUDIOPROC: no areas/world.trg, proc engine idle.
```

`sayresponse`, all three carry states, driven from a real client. On
the ground (after `drop talisman`, visible in the room), then carried
(after `get talisman`), then worn (`You don a porcelain ear talisman on
your head.` — worn on head), the same say produced the same reply:

```
You say 'the oracle waits'
A porcelain ear talisman replies, 'The ear has heard you. Ask the curator below.'
```

and from a second connected character standing in the room while the
(invisible) immortal wore the talisman and spoke:

```
Someone says 'the oracle waits'
A porcelain ear talisman replies, 'The ear has heard you. Ask the curator below.'
```

A say with no keyword match (`say nothing to see here`) produced
silence.

`transporter`, on a ground object configured `sanctum 950002`:

```
You step into a basalt standing arch...
The Cinder Stair
```

— the actor moved rooms, the room saw `$n steps into $p and
vanishes.`, and the arrival room rendered. A non-matching keyword fell
through to the normal error (`There is no nothingness here.`). A
second keyword on the same arch pointing at a room that does not exist
(`void 999999`) produced the fire-time validation path, player-side
`It doesn't seem to lead anywhere.` and, in the status log:

```
Sun Aug  2 05:22:46 2026::proclib transporter: obj 950081 keyword 'void' leads to missing room 999999
```

The regression case — an object authored with an unknown name
(`_proclib_frobnicate`) — loaded twice with no error and no log line,
kept its extra-description verbatim, set no flags, and answered
nothing. `stat obj` on the untouched instance:

```
Extra description keyword(s):
----------
_proclib_frobnicate
brick mundane
----------
```

with no `PROCLIB` in its flags, exactly the pre-PR behaviour.

The in-game path, end to end: `proclib obj brick add zzz` lists the
grown registry —

```
Available proclibs for objects:
transporter - 'enter <keyword>' teleports the actor to a room.
sayresponse - Object replies when a player says a keyword.
hummer - Items 'hums' - similar to some artifact weapons.
actworn - Object 'acts' while being worn/equiped by a character.
actroom - Object 'acts' to the room when on the ground.
```

— a bad parameter list prints the hoisted help text
(`Params: keyword roomvnum ...`), and a real add
(`proclib obj brick add sayresponse 'echo' '...'`) answered
`Proc successfully added.` and the brick replied to `say echo` on the
next line. `stat obj` on that brick shows the parsed
`_proclib_sayresponse1` beside the kept `_proclib_frobnicate`, and
`Extra flags: PROCLIB (2048)`.

### Trade-offs

* The `\xFF`-joined parameter string is the existing proclib storage
  idiom, inherited as-is for compatibility — this PR does not try to
  improve it, only to join it.
* `sayresponse` matches by case-insensitive substring over the whole
  say, which is what the legacy content was written against; a
  word-boundary matcher would be a behaviour change for that content.
* The bridge occupies a free `func.obj` slot per proclib-carrying vnum.
  If a later hand-written proc is assigned to such a vnum in
  `specs.assign.c`, the assignment wins at boot (assignment happens
  before any instance is read) — but the reverse order inside one boot
  cannot occur, because `proclibObj_add()` checks for NULL first.

### Trying it yourself

* Build: `git archive` this branch into a scratch tree, `cd src &&
  make -j16`. Expect exit 0, 226 objects, your warning set unchanged.
* Give any object in a zone you own an extra-description keyword
  `_proclib_sayresponse` with description
  `'ward warden' 'Not one step closer.'`, boot, `load` it, drop it, and
  say a sentence containing `ward` — it replies. Add
  `_proclib_transporter` with `below 3001` to a ground object and
  `enter below` teleports you to 3001; `enter anythingelse` behaves as
  before.
* Or skip the file: `proclib obj <target> add sayresponse 'ward'
  'Not one step closer.'` on a live object, then say `ward`.
