### PR TITLE
Enforce AFF3_SILVER and AFF3_PLUS* in melee, off by default

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -158,6 +158,7 @@ OBJS =  $(SHIP_OBJS) \
 				 persistence_queue.o \
 				 sql_persistence_raw.o \
 				 sql_pool.o \
+				 plushit.o \
 				 poll.o \
 				 prompt.o \
 				 properties.o \

--- a/src/fight.c
+++ b/src/fight.c
@@ -42,6 +42,7 @@
 #include "objmisc.h"
 #include "outposts.h"
 #include "paladins.h"
+#include "plushit.h"
 #include "reavers.h"
 #include "redis.h"
 #include "siege.h"
@@ -6512,6 +6513,9 @@ bool hit(P_char ch, P_char victim, P_obj weapon, int *damAccumulator)
 
 	if (weapon && weapon->type != ITEM_WEAPON)
 		weapon = NULL;
+
+	if (plushit_blocks(ch, victim, weapon)) /* AFF3_SILVER / AFF3_PLUS* enforcement; no-op unless enabled in lib/duris.properties */
+		return FALSE;
 
 	if ((IS_PC(ch) || IS_PC_PET(ch)) && IS_PC(victim) && !IS_AFFECTED5(ch, AFF5_NOT_OFFENSIVE))
 	{

--- a/src/plushit.c
+++ b/src/plushit.c
@@ -1,0 +1,211 @@
+/*
+   ***************************************************************************
+   *  File: plushit.c                                         Part of Duris *
+   *  Usage: enforce AFF3_SILVER / AFF3_PLUSONE..PLUSFIVE in melee          *
+   ***************************************************************************
+   *
+   * WHAT WAS ALREADY THERE, AND WHAT WAS NOT
+   * ----------------------------------------
+   * defines.h:723-728 has carried these six bits for decades:
+   *
+   *     AFF3_SILVER    BIT_10   "Char needs silver to dam"
+   *     AFF3_PLUSONE   BIT_11   "Char needs +1 to damage"
+   *     ...
+   *     AFF3_PLUSFIVE  BIT_15   "Char needs +5 to damage"
+   *
+   * An exhaustive search of master (2e4c95e8) finds them referenced in
+   * exactly four places, none of which is combat:
+   *
+   *     common.c:714-719        the stat/setbit label table
+   *     auction_houses.c:2078   the equipment search filters, which
+   *                             describe the bits on gear as "can cut
+   *                             lycanthropes" and "can hit ... magical
+   *                             creatures"
+   *     enhance.c:1288-1293    the item-enhancement grant table
+   *     utility.c:5152          remove_plushit_bits(), which strips the
+   *                             five plus bits from summoned and shaped
+   *                             mobs (callers in innates.c, magic.c,
+   *                             necromancy.c, sillusionist.c and three
+   *                             specs.* files) so that a summon does not
+   *                             inherit the protection of the thing it
+   *                             copies
+   *
+   * That last one is the proof of intent: the engine goes out of its way
+   * to remove a protection that is never enforced.
+   *
+   * WHAT THE CONTENT ACTUALLY SAYS  (measured over areas/ at 2e4c95e8)
+   * ------------------------------------------------------------------
+   * Mob sources (areas/mob/*.mob, 446 files, 20,127 records): FIVE carry
+   * a plus requirement - forofcon.mob #139930/#139975/#140039 (PLUSFIVE),
+   * mavulsk.mob #48 (PLUSONE), vecna.mob #130016 (PLUSFOUR).  ZERO carry
+   * AFF3_SILVER.  Of the five, only vecna is listed in areas/AREA, so
+   * exactly ONE flagged mob (#130016, Chressan) is in the world a stock
+   * boot builds; the other four exist in unlisted zone files.
+   *
+   * Object sources (areas/obj/*.obj, 443 files, 21,656 records): 385
+   * objects in 105 files carry ITEM2_SILVER (extra2 BIT_1, "Item harm
+   * AFF_SILVER"), 199 of them weapons.  ONE object grants an attacker a
+   * plus rating through bitvector3: heavens.obj #499 (PLUSFIVE), an
+   * immortal-zone item.
+   *
+   * So the silver rule has a fully-authored weapon side and no monsters
+   * to use it on; the plus rule has monsters and, outside the immortal
+   * zone, no authored weapon side.  Enforcement therefore has to define
+   * the weapon side, and it must not invent one that makes the flagged
+   * mobs unkillable.
+   *
+   * THE RULE  (written out so a designer can read it without reading C)
+   * ------------------------------------------------------------------
+   * The rule is skipped entirely - it never blocks - when the victim is
+   * a player or the attacker is trusted: the flags are authored on mobs
+   * and are never enforced against players or immortals.  Otherwise:
+   *
+   *   victim_need = highest AFF3_PLUS* bit set on the victim  (0..5)
+   *   weapon_plus = MAX of
+   *                   - the largest APPLY_HITROLL modifier on the wielded
+   *                     weapon itself, clamped to 0..5   <- the engine's
+   *                     own historical mapping, item_enchant.c:272-299,
+   *                     where a +1-hitroll weapon became ITEM2_PLUSONE
+   *                     and so on
+   *                   - 5 if the attacker carries AFF3_PLUSFIVE, 4 if
+   *                     PLUSFOUR ... 1 if PLUSONE.  A worn item's
+   *                     bitvector3 lands on affected_by3 through the
+   *                     ordinary affect rebuild, so a builder may grant
+   *                     the rating through gear - auction_houses.c:2079
+   *                     already describes the bits on equipment exactly
+   *                     that way
+   *   blocked     = weapon_plus < victim_need
+   *
+   *   silver_need = victim has AFF3_SILVER
+   *   silver_have = weapon has ITEM2_SILVER, or the weapon's material is
+   *                 MAT_SILVER or MAT_MITHRIL, or the attacker carries
+   *                 AFF3_SILVER
+   *   blocked     = silver_need && !silver_have
+   *
+   * Bare-handed attacks count as weapon_plus 0 / no silver, which is the
+   * point of the mechanic.  Only melee swings that resolve through hit()
+   * are gated; spells, breath weapons and direct damage procs are
+   * untouched.
+   *
+   * SHIPPING POSTURE
+   * ----------------
+   * Both halves default to OFF.  Turning the plus half on retunes the
+   * flagged encounters, and that is the immortal's call, not this
+   * patch's.  The switches are duris.properties keys read on every call
+   * (get_property() is a bsearch of the in-memory table), so an immortal
+   * can flip them on a running server - "properties set" when the key is
+   * present in lib/duris.properties, or add the line and "properties
+   * reload" - with no rebuild and no reboot:
+   *
+   *     combat.plushit.enforce   0
+   *     combat.silver.enforce    0
+   *
+   * THREADING
+   * ---------
+   * Pure function of its arguments plus two property reads.  No state.
+   */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "prototypes.h"
+#include "structs.h"
+#include "comm.h"
+#include "objmisc.h"
+#include "utils.h"
+#include "utility.h"
+#include "plushit.h"
+
+/* highest plus-rating a character DEMANDS of its attackers, 0 = none */
+static int plushit_required(P_char victim)
+{
+	if (!victim)
+		return 0;
+	if (IS_AFFECTED3(victim, AFF3_PLUSFIVE))
+		return 5;
+	if (IS_AFFECTED3(victim, AFF3_PLUSFOUR))
+		return 4;
+	if (IS_AFFECTED3(victim, AFF3_PLUSTHREE))
+		return 3;
+	if (IS_AFFECTED3(victim, AFF3_PLUSTWO))
+		return 2;
+	if (IS_AFFECTED3(victim, AFF3_PLUSONE))
+		return 1;
+	return 0;
+}
+
+/* plus-rating an attacker BRINGS, 0 = mundane */
+static int plushit_available(P_char ch, P_obj weapon)
+{
+	int rating = 0, i;
+
+	if (weapon)
+	{
+		for (i = 0; i < MAX_OBJ_AFFECT; i++)
+		{
+			if (weapon->affected[i].location == APPLY_HITROLL && (int)weapon->affected[i].modifier > rating)
+				rating = (int)weapon->affected[i].modifier;
+		}
+		if (rating > 5)
+			rating = 5;
+		if (rating < 0)
+			rating = 0;
+	}
+
+	/* a builder may state the rating outright through bitvector3 */
+	if (ch)
+	{
+		int direct = plushit_required(ch);        /* same bits, other side */
+
+		if (direct > rating)
+			rating = direct;
+	}
+	return rating;
+}
+
+static int silver_required(P_char victim) { return victim && IS_AFFECTED3(victim, AFF3_SILVER); }
+
+static int silver_available(P_char ch, P_obj weapon)
+{
+	if (weapon)
+	{
+		if (IS_SET(weapon->extra2_flags, ITEM2_SILVER))
+			return TRUE;
+		if (weapon->material == MAT_SILVER || weapon->material == MAT_MITHRIL)
+			return TRUE;
+	}
+	if (ch && IS_AFFECTED3(ch, AFF3_SILVER))
+		return TRUE;
+	return FALSE;
+}
+
+int plushit_blocks(P_char ch, P_char victim, P_obj weapon)
+{
+	int need;
+
+	if (!ch || !victim)
+		return FALSE;
+	/* the flags are authored on mobs; never turn them on a player, and
+	   never on an immortal's attack */
+	if (IS_PC(victim) || IS_TRUSTED(ch))
+		return FALSE;
+
+	if (get_property("combat.silver.enforce", 0) && silver_required(victim) && !silver_available(ch, weapon))
+	{
+		act("Your blow passes through $N as if $E were not there - silver, and nothing else, will bite.", FALSE, ch, 0, victim, TO_CHAR);
+		act("$n's blow passes harmlessly through $N.", TRUE, ch, 0, victim, TO_ROOM);
+		return TRUE;
+	}
+
+	if (get_property("combat.plushit.enforce", 0))
+	{
+		need = plushit_required(victim);
+		if (need > 0 && plushit_available(ch, weapon) < need)
+		{
+			act("Your weapon is not enchanted enough to harm $N.", FALSE, ch, 0, victim, TO_CHAR);
+			act("$n's weapon glances off $N without leaving a mark.", TRUE, ch, 0, victim, TO_ROOM);
+			return TRUE;
+		}
+	}
+	return FALSE;
+}

--- a/src/plushit.h
+++ b/src/plushit.h
@@ -1,0 +1,27 @@
+/*
+   ***************************************************************************
+   *  File: plushit.h                                         Part of Duris *
+   *  Usage: enforce AFF3_SILVER and AFF3_PLUSONE..PLUSFIVE in melee.      *
+   *                                                                        *
+   *  Two source files and one two-line guard in fight.c's hit(), with no  *
+   *  dependency on anything else new.                                     *
+   *                                                                        *
+   *  It ships DISABLED.  Both switches read lib/duris.properties at call  *
+   *  time, so enabling, tuning or reverting needs no recompile and no     *
+   *  reboot:                                                              *
+   *      combat.plushit.enforce   0 = off (default), 1 = on               *
+   *      combat.silver.enforce    0 = off (default), 1 = on               *
+   ***************************************************************************
+ */
+
+#ifndef _PLUSHIT_H_
+#define _PLUSHIT_H_
+
+#include "structs.h"
+
+/* TRUE  -> ch cannot hurt victim with this weapon; hit() should abort.
+   FALSE -> proceed exactly as before.  Never TRUE while both properties
+   are 0, so an unconfigured server behaves identically to master. */
+int plushit_blocks(P_char ch, P_char victim, P_obj weapon);
+
+#endif /* _PLUSHIT_H_ */

--- a/tests/async/test_plushit_module_contract.py
+++ b/tests/async/test_plushit_module_contract.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+source = (ROOT / "src/plushit.c").read_text()
+header = (ROOT / "src/plushit.h").read_text()
+fight = (ROOT / "src/fight.c").read_text()
+makefile = (ROOT / "src/Makefile").read_text()
+properties = (ROOT / "lib/duris.properties").read_text()
+
+# the module owns the whole rule
+for symbol in (
+    "plushit_required",
+    "plushit_available",
+    "silver_required",
+    "silver_available",
+    "int plushit_blocks(",
+    "APPLY_HITROLL",
+    "ITEM2_SILVER",
+    "MAT_SILVER",
+    "MAT_MITHRIL",
+):
+    assert symbol in source, symbol
+
+# both switches are read per call and default to off
+assert 'get_property("combat.plushit.enforce", 0)' in source
+assert 'get_property("combat.silver.enforce", 0)' in source
+
+# the rule is never enforced against players or for trusted attackers
+assert "IS_PC(victim) || IS_TRUSTED(ch)" in source
+
+# fight.c carries exactly one guard, and it only ever aborts the swing
+assert fight.count("plushit_blocks(") == 1
+assert '#include "plushit.h"' in fight
+assert "if (plushit_blocks(ch, victim, weapon))" in fight
+
+# one object line
+assert "plushit.o" in makefile
+
+# the public surface is one predicate
+assert "int plushit_blocks(P_char ch, P_char victim, P_obj weapon);" in header
+
+# ships off: the stock properties file carries neither key
+assert "combat.plushit.enforce" not in properties
+assert "combat.silver.enforce" not in properties
+
+print("plushit module contract passed")


### PR DESCRIPTION

**Merging this changes nothing.** Both halves of the rule ship disabled
behind two `duris.properties` keys that do not exist in the stock file
(`combat.plushit.enforce`, `combat.silver.enforce`); `get_property()`
falls back to 0, and the guard returns immediately. A server that never
adds the keys behaves identically to master — that is proven below on a
live boot, not asserted. What an admin who turns a key on gets: the
classic monster protections builders have been flagging for years —
"needs silver to damage", "needs a +N weapon to damage" — finally do
something.

### What was already there, and what was not

`defines.h:723-728` has carried the six bits for decades:

```
AFF3_SILVER    BIT_10   "Char needs silver to dam"
AFF3_PLUSONE   BIT_11   "Char needs +1 to damage"
...
AFF3_PLUSFIVE  BIT_15   "Char needs +5 to damage"
```

An exhaustive search of master finds them referenced in
exactly four places, none of which is combat: the stat/setbit label
table (common.c:714-719), the auction-house equipment filters —
which describe the bits on gear as "can cut lycanthropes" and "can hit
... magical creatures" (auction_houses.c:2078) — the item-enhancement
grant table (enhance.c:1288-1293), and `remove_plushit_bits()`
(utility.c:5152), which strips the five plus bits from summoned and
shaped mobs in seven files so a summon does not inherit the protection
of the thing it copies. That last one is the proof of intent: the
engine goes out of its way to remove a protection that is never
enforced.

What the content says, measured over `areas/`:

* Mob sources (446 `.mob` files, 20,127 records): **five** mobs carry a
  plus requirement — `forofcon.mob` #139930/#139975/#140039 (PLUSFIVE),
  `mavulsk.mob` #48 (PLUSONE), `vecna.mob` #130016 (PLUSFOUR). **Zero**
  carry AFF3_SILVER. Of the five, only `vecna` is listed in
  `areas/AREA`, so exactly **one** flagged mob — Chressan — is in the
  world a stock boot builds; the other four sit in zone files the AREA
  list does not currently include.
* Object sources (443 `.obj` files, 21,656 records): **385** objects in
  105 files carry ITEM2_SILVER ("Item harm AFF_SILVER"), 199 of them
  weapons. **One** object grants an attacker a plus rating through
  `bitvector3`: heavens.obj #499 (PLUSFIVE), an immortal-zone item.

So the silver rule has a fully authored weapon side and no monsters to
use it on, and the plus rule has monsters and (outside the immortal
zone) no authored weapon side. Enforcement has to define the weapon
side, and the engine's own dead code says how: `item_enchant.c:272-299`
(not in the Makefile, and referencing `ITEM2_PLUS*` constants that no
longer exist) mapped a weapon's APPLY_HITROLL modifier 1..5 straight
onto its plus rating. That mapping is adopted — resurrected archaeology,
not a new invention — clamped to 0..5. It is a definition a maintainer
may legitimately want to debate, which is one reason this PR is
separate from everything else and off by default.

### The rule, exactly as coded

The rule is skipped entirely — it never blocks — when the victim is a
player or the attacker is trusted. Otherwise, per melee swing in
`hit()`:

* **Plus:** blocked when the victim's highest AFF3_PLUS* bit exceeds
  what the attacker brings: the largest APPLY_HITROLL modifier on the
  wielded weapon itself (clamped 0..5), or any AFF3_PLUS* bit the
  attacker carries — a worn item's `bitvector3` reaches `affected_by3`
  through the ordinary affect rebuild, so a builder can grant the
  rating through gear, which is exactly how the auction-house filter
  already describes those bits on equipment.
* **Silver:** blocked when the victim has AFF3_SILVER and the weapon
  has neither ITEM2_SILVER nor material silver/mithril, and the
  attacker does not carry AFF3_SILVER.

Bare hands are plus 0 and not silver, which is the point of the
mechanic. Only swings that resolve through `hit()` are gated: spells,
breath weapons and direct damage procs are untouched, and NPC attackers
are subject to the rule too (a charmed pet needs silver like its
owner). Hitroll from other worn gear, strength or skill does not count
— only the weapon's own enchantment, per the item_enchant.c lineage. A
blocked swing prints an act() pair and does no damage.

### Footprint

One commit. New files: `src/plushit.c` (211 lines, more than half of it
the header comment stating everything above), `src/plushit.h` (27), and
`tests/async/test_plushit_module_contract.py` (47, in the shape of
`test_mining_module_contract.py`) pinning the off-by-default contract:
defaults 0 in the module, exactly one guard in `hit()`, and a stock
properties file that carries neither key.

Existing files: `Makefile` +1 (`plushit.o`, in the p-section — it does
not touch the region the studioproc PR's Makefile line lands in, so the
two merge cleanly in either order; this PR shares no code with that one
and stands alone), `fight.c` +4 — the include, and:

```c
if (plushit_blocks(ch, victim, weapon)) /* AFF3_SILVER / AFF3_PLUS* enforcement; no-op unless enabled in lib/duris.properties */
    return FALSE;
```

placed after the `weapon = NULL` normalisation in `hit()`
(fight.c:7053), so it sees the weapon combat will actually use.

### The switches, operationally

The keys are read on every call — `get_property()` is a bsearch of the
in-memory table — so a flip needs no rebuild and no reboot: add the
line to `lib/duris.properties` and `properties reload`, or pre-seed it
at 0 and `properties set combat.silver.enforce 1` live (both are
FORGER-level commands). Both were exercised on the running test server;
the flip takes effect on the next swing. With no keys anywhere,
`get_property()` returns the compiled default 0. The keys introduce a
`combat.` prefix that the file does not use yet; happy to rename to
taste.

### Evidence

Build, from a pristine `git archive` of this branch rebased onto master
`5aebae17`: exit 0, 224 objects (master's 223 + plushit.o), 273
warnings, and the normalised warning set (file + message, line numbers
stripped) is byte-identical to master built the same way. Zero of the
273 come from plushit.c.

Booted on a side port against a scratch database, three states, one
server process throughout — every flip below happened live, no reboot.
Test fixture: a level-4 cow (`load char 1405`), flagged in-game with
`setbit char cow aff3 SILVER 1` (or PLUSTWO), attacked by a level-56
mortal warrior. `stat` confirms the flag before each fight, e.g.
`Affected by (3): 131584 - SILVER COVER`.

**Keys off (the merge case).** `properties show combat*` lists nothing;
the stock file carries neither key. The mortal, plain steel dagger,
kills the SILVER-flagged cow exactly as on a master build of the same
tree booted the same way — same message shape, same kill, and the
deflect lines below appear nowhere in the session:

```
-=[Your impressive pierce causes a cow to grimace in pain.]=-
A cow is incapacitated and will slowly die, if not aided.
...
A cow is dead! R.I.P.
```

**Silver on.** The key was added to the file while the server ran;
`properties reload`; `properties show combat*` then reports
`combat.silver.enforce: 1.000`. The same plain-dagger attack now
bounces, every swing, cow unharmed:

```
Your blow passes through a cow as if it were not there - silver, and nothing else, will bite.
```

(room view: `Zerrick's blow passes harmlessly through a cow.`)

A silver dagger (obj #622, ITEM2_SILVER, zero hitroll) lands and kills.
The documented bypasses work: with `setbit char Zerrick aff3 SILVER 1`
the attacker-side grant lets the same mundane weapons land, and a
trusted immortal hits the flagged cow bare-handed. Flipped back off
live with `properties set combat.silver.enforce 0`.

**Plus on** (silver off — the keys are independent). A PLUSTWO-flagged
cow against a zero-hitroll weapon — the silver dagger, which also shows
silver rating is not plus rating:

```
Your weapon is not enchanted enough to harm a cow.
```

(room view: `Zerrick's weapon glances off a cow without leaving a mark.`)

A +4 longsword (obj #37, APPLY_HITROLL 4 >= 2) lands and kills. And the
one live carrier, loaded and statted on this boot: Chressan
(`vecna` #130016), `Affected by (3): 139264 - PLUSFOUR COVER` — with
the key on, that fight genuinely requires a +4-or-better weapon or a
granted plus rating.

### What turning it on does to existing encounters

Enabling silver changes nothing today — no booted mob carries
AFF3_SILVER — it hands builders a switch that 385 already-authored
silver weapons have been waiting for. Enabling plus retunes exactly one
encounter in the current boot set (Chressan, +4 to hit), and up to four
more (`forofcon` ×3 at +5, `mavulsk` ×1 at +1) if those zones are ever
returned to the AREA list. Whether those fights should demand an
enchanted weapon, and how the plus rating should be sourced, is a
tuning decision that belongs to whoever runs the server — which is
precisely why both halves ship off, flippable and revertible at
runtime, and why nothing here retunes anything on merge.

Other trade-offs worth naming: skills that deal damage without routing
through `hit()` are not gated — this enforces the melee swing, not
every damage source. Monks and anyone else bare-handed are plus 0 by
design. The deflect messages are new authored text; wording is easily
changed. The per-swing cost when a key is on is one or two bsearch
property lookups — `fight.c` already calls `get_property()` in 199
places, so this is house style, not a new pattern; with both keys off
the predicate is two integer compares and two bsearches after the
PC/trusted short-circuit.

### Trying it yourself

* Build: `git archive` this branch into a scratch tree, `cd src &&
  make -j16`. Expect exit 0, 224 objects, your warning set unchanged
  (273 on g++ 13 against master `5aebae17`). `python3
  tests/async/test_plushit_module_contract.py` from the tree root
  prints `plushit module contract passed`.
* Boot with a stock properties file: combat is unchanged; there is
  nothing to see, which is the point. Verify with a flagged mob if you
  like: `setbit char <mob> aff3 SILVER 1`, hit it — it dies as usual.
* Flip it: add `combat.silver.enforce=1` to `lib/duris.properties`,
  `properties reload`, hit the same mob with a plain weapon, and it
  will not bite. `properties set combat.silver.enforce 0` puts it back,
  no reboot at any step.
