### PR TITLE
Fix build wrt tether.h include.

### DIFF
--- a/src/fight.c
+++ b/src/fight.c
@@ -49,7 +49,6 @@
 #include "sql.h"
 #include "sql_player.h"
 #include "studioproc.h"
-#include "tether.h"
 #include "vnum.obj.h"
 #include "weather.h"
 #include "world_quest.h"


### PR DESCRIPTION
For some reason the include came back in f8a0349d638a6f248ebbe22e9bc2aa5e5ed3558c.