### PR TITLE
fix(sql): harden pooled persistence and migration boundaries

### DIFF
--- a/migrations/run_migration.sh
+++ b/migrations/run_migration.sh
@@ -20,7 +20,9 @@ else
     exit 2
 fi
 
-MYSQL_CMD="mysql -h$DB_HOST -P${DB_PORT:-3306} -u$DB_USER -p$DB_PASSWD $DB_NAME"
+MYSQL_PWD="$DB_PASSWD"
+export MYSQL_PWD
+MYSQL=(mysql -h "$DB_HOST" -P "${DB_PORT:-3306}" -u "$DB_USER" "$DB_NAME")
 
 STEP=0
 TOTAL=112
@@ -36,7 +38,7 @@ run_sql() {
     echo "$sql" > "$tmpfile"
 
     local err_file=$(mktemp)
-    if $MYSQL_CMD < "$tmpfile" 2>"$err_file"; then
+    if "${MYSQL[@]}" < "$tmpfile" 2>"$err_file"; then
         echo "ok"
     else
         echo "FAILED"
@@ -55,7 +57,7 @@ run_sql_file() {
 
     local err_file
     err_file=$(mktemp)
-    if $MYSQL_CMD < "$sql_file" 2>"$err_file"; then
+    if "${MYSQL[@]}" < "$sql_file" 2>"$err_file"; then
         echo "ok"
     else
         echo "FAILED"
@@ -96,21 +98,21 @@ convert_tables_to_charset() {
     local tables=""
     local table_failed=0
 
-    if ! db_charset=$($MYSQL_CMD -N -e "SELECT DEFAULT_CHARACTER_SET_NAME FROM information_schema.SCHEMATA WHERE SCHEMA_NAME=DATABASE();" 2>/dev/null); then
+    if ! db_charset=$("${MYSQL[@]}" -N -e "SELECT DEFAULT_CHARACTER_SET_NAME FROM information_schema.SCHEMATA WHERE SCHEMA_NAME=DATABASE();" 2>/dev/null); then
         echo "FAILED"
         FAILED=$((FAILED + 1))
         return 1
     fi
 
     if [ "$with_collation" = "1" ]; then
-        if ! db_collation=$($MYSQL_CMD -N -e "SELECT DEFAULT_COLLATION_NAME FROM information_schema.SCHEMATA WHERE SCHEMA_NAME=DATABASE();" 2>/dev/null); then
+        if ! db_collation=$("${MYSQL[@]}" -N -e "SELECT DEFAULT_COLLATION_NAME FROM information_schema.SCHEMATA WHERE SCHEMA_NAME=DATABASE();" 2>/dev/null); then
             echo "FAILED"
             FAILED=$((FAILED + 1))
             return 1
         fi
     fi
 
-    if ! tables=$($MYSQL_CMD -N -e "SELECT table_name FROM information_schema.tables WHERE table_schema=DATABASE() AND table_type='BASE TABLE';" 2>/dev/null); then
+    if ! tables=$("${MYSQL[@]}" -N -e "SELECT table_name FROM information_schema.tables WHERE table_schema=DATABASE() AND table_type='BASE TABLE';" 2>/dev/null); then
         echo "FAILED"
         FAILED=$((FAILED + 1))
         return 1
@@ -122,7 +124,7 @@ convert_tables_to_charset() {
             local err_file
             err_file=$(mktemp)
             if [ "$with_collation" = "1" ]; then
-                if $MYSQL_CMD -e "SET sql_mode=''; SET FOREIGN_KEY_CHECKS=0; ALTER TABLE \`$t\` CONVERT TO CHARACTER SET $db_charset COLLATE $db_collation; SET FOREIGN_KEY_CHECKS=1;" >/dev/null 2>"$err_file"; then
+                if "${MYSQL[@]}" -e "SET sql_mode=''; SET FOREIGN_KEY_CHECKS=0; ALTER TABLE \`$t\` CONVERT TO CHARACTER SET $db_charset COLLATE $db_collation; SET FOREIGN_KEY_CHECKS=1;" >/dev/null 2>"$err_file"; then
                     :
                 else
                     if [ "$table_failed" -eq 0 ]; then
@@ -132,7 +134,7 @@ convert_tables_to_charset() {
                     head -20 "$err_file"
                 fi
             else
-                if $MYSQL_CMD -e "SET sql_mode=''; SET FOREIGN_KEY_CHECKS=0; ALTER TABLE \`$t\` CONVERT TO CHARACTER SET $db_charset; SET FOREIGN_KEY_CHECKS=1;" >/dev/null 2>"$err_file"; then
+                if "${MYSQL[@]}" -e "SET sql_mode=''; SET FOREIGN_KEY_CHECKS=0; ALTER TABLE \`$t\` CONVERT TO CHARACTER SET $db_charset; SET FOREIGN_KEY_CHECKS=1;" >/dev/null 2>"$err_file"; then
                     :
                 else
                     if [ "$table_failed" -eq 0 ]; then

--- a/src/locker_async.c
+++ b/src/locker_async.c
@@ -629,82 +629,72 @@ fail:
 
 /* ---------------- worker ---------------- */
 
-static int apply_sql_script(MYSQL *conn, const char *sql)
+static int repair_failed_connection(MYSQL **conn_io)
 {
-	const char *p;
-	const char *q;
-	char *stmt;
-	size_t n;
-	int status;
+	MYSQL *conn;
+	MYSQL *replacement;
 
-	if (!conn || !sql)
+	if (!conn_io || !*conn_io)
 		return 0;
 
-	p = sql;
-	while (*p == ' ' || *p == '\n' || *p == '\r' || *p == '\t')
-		p++;
-	if (!*p)
+	conn = *conn_io;
+
+	/* A failed multi-statement may leave result packets pending.  Drain
+	 * before issuing ROLLBACK; otherwise the connection can remain out of
+	 * sync and cannot be safely reused. */
+	sql_clear_results_on(conn);
+	if (mysql_rollback(conn) != 0)
+		logit(LOG_FILE, "locker_async: rollback after failed snapshot failed: %s", mysql_error(conn));
+
+	/* The connection may still have an unknown server-side state (for
+	 * example, a dropped socket or a failed statement in a batch).  Discard
+	 * it rather than returning it to the shared worker pool. */
+	replacement = sql_pool_replace_connection(conn);
+	if (replacement)
+		*conn_io = replacement;
+	else
+		logit(LOG_FILE, "locker_async: failed to replace poisoned persistence connection");
+	return 0;
+}
+
+static int apply_sql_script(MYSQL **conn_io, const char *sql)
+{
+	MYSQL *conn;
+	int status;
+
+	if (!conn_io || !*conn_io || !sql)
+		return 0;
+
+	conn = *conn_io;
+	while (*sql == ' ' || *sql == '\n' || *sql == '\r' || *sql == '	')
+		sql++;
+	if (!*sql)
 		return 1;
-	if (p[0] == '/' && p[1] == '*')
+	if (sql[0] == '/' && sql[1] == '*')
 		return 1;
 
-	/* Prefer multi-statement when connection supports it. */
-	if (mysql_real_query(conn, sql, (unsigned long)strlen(sql)) == 0)
+	/* Every persistence-pool connection is created with
+	 * CLIENT_MULTI_STATEMENTS. Do not retry a partially executed batch by
+	 * splitting it: that can duplicate successful statements and leaves the
+	 * transaction boundary ambiguous. */
+	if (mysql_real_query(conn, sql, (unsigned long)strlen(sql)) != 0)
 	{
-		do
-		{
-			MYSQL_RES *res = mysql_store_result(conn);
-			if (res)
-				mysql_free_result(res);
-			status = mysql_next_result(conn);
-			if (status > 0)
-			{
-				logit(LOG_FILE, "locker_async: multi result error: %s", mysql_error(conn));
-				return 0;
-			}
-		} while (status == 0);
-		return 1;
+		logit(LOG_FILE, "locker_async: multi-statement snapshot failed: %s", mysql_error(conn));
+		return repair_failed_connection(conn_io);
 	}
 
-	/* Fallback: split on ";\n". */
-	p = sql;
-	while (*p)
+	do
 	{
-		while (*p == ' ' || *p == '\n' || *p == '\r' || *p == '\t')
-			p++;
-		if (!*p)
-			break;
-		q = strstr(p, ";\n");
-		if (!q)
-			q = p + strlen(p);
-		n = (size_t)(q - p);
-		while (n > 0 && (p[n - 1] == ' ' || p[n - 1] == '\n' || p[n - 1] == '\r' ||
-		                 p[n - 1] == '\t' || p[n - 1] == ';'))
-			n--;
-		if (n > 0)
+		MYSQL_RES *res = mysql_store_result(conn);
+		if (res)
+			mysql_free_result(res);
+		status = mysql_next_result(conn);
+		if (status > 0)
 		{
-			stmt = (char *)malloc(n + 1);
-			if (!stmt)
-				return 0;
-			memcpy(stmt, p, n);
-			stmt[n] = '\0';
-			if (mysql_real_query(conn, stmt, (unsigned long)n) != 0)
-			{
-				logit(LOG_FILE, "locker_async: stmt failed: %s | sqlerr=%s", stmt, mysql_error(conn));
-				free(stmt);
-				return 0;
-			}
-			{
-				MYSQL_RES *res = mysql_store_result(conn);
-				if (res)
-					mysql_free_result(res);
-			}
-			free(stmt);
+			logit(LOG_FILE, "locker_async: multi result error: %s", mysql_error(conn));
+			return repair_failed_connection(conn_io);
 		}
-		if (!*q)
-			break;
-		p = q + 2;
-	}
+	} while (status == 0);
 	return 1;
 }
 
@@ -749,7 +739,7 @@ static void *locker_async_worker_main(void *arg)
 #ifndef __NO_MYSQL__
 		conn = sql_persistence_connection();
 		if (conn && job.sql)
-			res.ok = apply_sql_script(conn, job.sql) ? 1 : 0;
+			res.ok = apply_sql_script(&conn, job.sql) ? 1 : 0;
 		else if (job.sql && job.sql[0] == '/' && job.sql[1] == '*')
 			res.ok = 1;
 		if (conn)

--- a/src/sql.c
+++ b/src/sql.c
@@ -245,9 +245,24 @@ char *mysql_str(const char *str, char *buf)
 
 string escape_str(const char *str)
 {
-	static char buff[MAX_STRING_LENGTH];
-	mysql_real_escape_string(DB, buff, str, strlen(str));
-	return string(buff);
+	size_t len;
+	string escaped;
+	unsigned long escaped_len;
+
+	if (!str || !DB)
+		return string();
+
+	len = strlen(str);
+	if (len > (string().max_size() - 1) / 2)
+		return string();
+
+	/* mysql_real_escape_string() can expand every input byte and needs
+	 * one additional byte for the terminator.  Keep the storage owned by
+	 * this call so concurrent persistence workers cannot overwrite it. */
+	escaped.assign(len * 2 + 1, '\0');
+	escaped_len = mysql_real_escape_string(DB, &escaped[0], str, len);
+	escaped.resize(escaped_len);
+	return escaped;
 }
 
 /* populate races and classes lookup tables on boot */

--- a/tests/async/test_locker_connection_repair.py
+++ b/tests/async/test_locker_connection_repair.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""Regression contracts for pooled locker connection failure hygiene."""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+source = (ROOT / "src" / "locker_async.c").read_text(encoding="utf-8", errors="replace")
+
+checks = {
+    "failed connection has a repair helper": "static int repair_failed_connection(MYSQL **conn_io)" in source,
+    "pending results are drained before rollback": source.find("sql_clear_results_on(conn);") < source.find("mysql_rollback(conn)"),
+    "failed transactions are rolled back": "mysql_rollback(conn)" in source,
+    "poisoned pooled connections are replaced": "sql_pool_replace_connection(conn)" in source,
+    "replacement is returned to the worker release path": "apply_sql_script(&conn, job.sql)" in source,
+    "multi-statement failure does not split and replay the batch": "Fallback: split on" not in source,
+    "multi-result failure also repairs the connection": source.count("repair_failed_connection(conn_io)") >= 2,
+}
+
+for name, ok in checks.items():
+    print(("PASS" if ok else "FAIL") + ": " + name)
+
+raise SystemExit(0 if all(checks.values()) else 1)

--- a/tests/async/test_migration_mysql_invocation.py
+++ b/tests/async/test_migration_mysql_invocation.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Contract checks for shell-safe migration database invocation."""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+source = (ROOT / "migrations" / "run_migration.sh").read_text(encoding="utf-8", errors="replace")
+
+checks = {
+    "password is passed through MYSQL_PWD": 'MYSQL_PWD="$DB_PASSWD"' in source,
+    "password environment is exported": "export MYSQL_PWD" in source,
+    "mysql arguments are represented as an array": "MYSQL=(mysql -h" in source,
+    "array invocation is quoted": '"${MYSQL[@]}"' in source,
+    "legacy shell command string is gone": "MYSQL_CMD=" not in source,
+    "legacy unquoted execution is gone": "$MYSQL_CMD" not in source,
+}
+
+for name, ok in checks.items():
+    print(("PASS" if ok else "FAIL") + ": " + name)
+
+raise SystemExit(0 if all(checks.values()) else 1)

--- a/tests/async/test_sql_escape_contract.py
+++ b/tests/async/test_sql_escape_contract.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Contract checks for the thread-safe, correctly sized SQL escape helper."""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+source = (ROOT / "src" / "sql.c").read_text(encoding="utf-8", errors="replace")
+
+checks = {
+    "no shared escape buffer": "static char buff[MAX_STRING_LENGTH];\n\tmysql_real_escape_string(DB, buff, str, strlen(str));" not in source,
+    "null input and DB are rejected": "if (!str || !DB)" in source,
+    "worst-case expansion is bounded": "(string().max_size() - 1) / 2" in source,
+    "owned dynamic storage is allocated": "escaped.assign(len * 2 + 1, '\\0')" in source,
+    "connector result length is honored": "escaped.resize(escaped_len)" in source,
+}
+
+for name, ok in checks.items():
+    print(("PASS" if ok else "FAIL") + ": " + name)
+
+raise SystemExit(0 if all(checks.values()) else 1)


### PR DESCRIPTION
## Summary

Harden SQL-backed persistence and migration failure paths so failed locker batches cannot poison pooled connections or corrupt subsequent writes.

This PR is limited to SQL/data-integrity behavior. WebSocket authentication hardening is handled separately.

## Changes

- Replace the shared static `escape_str()` buffer with per-call storage sized for MySQL's worst-case `2n + 1` expansion.
- Prevent concurrent persistence workers from overwriting each other's escaped SQL data.
- Drain pending MySQL results before rollback after a failed locker multi-statement.
- Replace a failed pooled connection instead of returning unknown transaction/protocol state to the pool.
- Remove the unsafe fallback that split and replayed a partially executed multi-statement batch.
- Replace the migration runner's unquoted `MYSQL_CMD` shell string with a quoted argument array and `MYSQL_PWD`.

## Why

The previous locker failure path could return a connection to the worker pool after a partial multi-statement failure without reliably draining results or rolling back. A later worker could inherit pending results, transaction state, or locks.

The previous `escape_str()` implementation used a process-wide static buffer, which was unsafe for concurrent callers and did not provide enough storage for MySQL's documented maximum expansion.

The migration command construction depended on shell parsing of the database password and command arguments.

## Verification

### Passed

- Clean build: `make -C src clean && make -C src -j1`
- SQL/persistence/migration/locker contract checks: 103 passed in the complete repository contract sweep
- Migration shell syntax checks
- `git diff --check`
- SQL escaping runtime harness with a 40,000-byte quote-heavy input
- Disposable MariaDB fault-injection harness using `CLIENT_MULTI_STATEMENTS`

The database fault-injection result was:

```text
injected_failure query_rc=0 result_status=1
after_repair rows=0 borrowed_thread_transactions=0
after_recovery recovery_rows=1
```

This proves that a failed batch reports an error, leaves no partial row, leaves no transaction on the failed connection, and allows a replacement connection to commit the next job.

### Existing baseline failures

The complete repository sweep reported three unrelated failures:

- `tests/async/test_actwiz_save_logging.py`
- `tests/async/test_epic_save_guards.py`
- `tests/async/test_save_logging_sweep.py`

Each reproduces identically on unmodified `community-duris/master`; none touches the SQL files or behavior changed here.

## Scope

This PR does not change:

- WebSocket authentication;
- gameplay behavior;
- database table definitions;
- production migration data;
- the separate WebSocket hardening work.

No configured or production database was modified. The database test used disposable MariaDB containers and those containers/volumes were removed after verification.
