### PR TITLE
Reduce player-event, persistence, locker, and affect latency

### DIFF
--- a/lib/duris.properties
+++ b/lib/duris.properties
@@ -2642,7 +2642,6 @@ smoke.gootwiet.saveBonusChance=75.000
 
 # Help command rate limiting (anti-DoS protection)
 help.cooldown.secs=2.000
-help.lag.pulses=4.000
 
 # Auto-Reboot Settings
 # Threshold: Number of hours of uptime before auto-reboot triggers

--- a/lib/information/help_index
+++ b/lib/information/help_index
@@ -9061,8 +9061,8 @@ will crumble and items flagged no rent will disappear. Anyone who is on
 your grant list will be able to access your locker as well. Please see 
 "help grant" for information on giving others access to your locker!
 
-To help with sorting and finding eq stored in a locker the command "quit 
-sort" can be used. Typing that while in the locker will show a long list 
+To help with sorting and finding eq stored in a locker the command "equip
+sort" can be used. Typing that while in the locker will show a long list
 of options to sort eq by. If the player proceeds to sort eq by one of 
 those stats it will place all items that have this stat in another chest 
 inside the locker, 2.chest.
@@ -9071,8 +9071,36 @@ Example:
 syntax: equip sort wis_max
 
 This will place all items that have the max_wis stat in 2.chest.
+
+If you need the complete list of sort types, use "equip sort help" while
+inside the locker. The same information is available with "help equip sort".
 ===========================================================================
 See also: BANKS, GRANT
+
+#
+EQUIP SORT (Locker Command)
+===========================================================================
+Syntax: equip sort help
+        equip sort short
+        equip sort long
+        equip sort all
+        equip sort <type1> [type2] [type3] ...
+        equip sort custom <type1> [type2] [type3] ...
+        equip sort none
+
+This command is available inside a storage locker. It creates sorting
+chests and moves matching equipment into them. The command may take longer
+when the locker contains a large number of items because the locker must be
+rebuilt and saved.
+
+Use "equip sort help" for the available short sort names. Use "help equip sort"
+for the same instructions. Use "short" for a compact list, "long" for
+descriptions, and "all" for every available sort type. "custom" combines
+several criteria into one chest. "none" removes generated sorting chests and
+returns items to the unsorted chest.
+
+See also: LOCKER STORAGE, STAT
+===========================================================================
 
 #
 LOOK (General Information)

--- a/src/actinf.c
+++ b/src/actinf.c
@@ -5794,11 +5794,10 @@ void do_weather(P_char ch, char *argument, int cmd)
 void do_help(P_char ch, char *argument, int cmd)
 {
 	char *attribs;
-	int   help_cooldown, help_lag;
+	int   help_cooldown;
 
 	// Get configurable rate limit values
 	help_cooldown = (int)get_property("help.cooldown.secs", 2);
-	help_lag      = (int)get_property("help.lag.pulses", WAIT_SEC);
 
 	// Check cooldown timer (prevent rapid spam)
 	if (!affect_timer(ch, help_cooldown, TAG_HELP_COOLDOWN))
@@ -5815,8 +5814,6 @@ void do_help(P_char ch, char *argument, int cmd)
 	if (attribs)
 		send_to_char(attribs, ch);
 
-	// Impose command lag (prevent queuing)
-	CharWait(ch, help_lag);
 }
 
 void do_wizhelp(P_char ch, char *argument, int cmd)

--- a/src/actoth.c
+++ b/src/actoth.c
@@ -1664,8 +1664,7 @@ void event_autosave(P_char ch, P_char victim, P_obj obj, void *data)
 		return;
 	}
 	persistence_flush_item_events(64);
-	if (!do_save_silent(ch, 1))
-		logit(LOG_DEBUG, "Failed to autosave %s.", GET_NAME(ch));
+	persistence_schedule_character_save(ch, 1, 2, "autosave");
 	add_event(event_autosave, 1200, ch, 0, 0, 0, 0, 0);
 }
 
@@ -2030,21 +2029,10 @@ void do_save(P_char ch, char *argument, int cmd)
 		else
 			wizlog(OVERLORD, "Pet %s saved to file %ld!", GET_NAME(ch), GET_IDNUM(ch));
 	}
-	snprintf(Gbuf1, MAX_STRING_LENGTH, "Saving %s.\r\n", GET_NAME(GET_PLYR(ch)));
+	snprintf(Gbuf1, MAX_STRING_LENGTH, "Save queued for %s.\r\n", GET_NAME(GET_PLYR(ch)));
 	send_to_char(Gbuf1, ch);
 	update_pos(ch);
-
-	logit(LOG_FILE, "[TRACE] do_save manual begin name=%s pid=%d room=%d", GET_NAME(ch), GET_PID(ch), ch->in_room);
-	if (!writeCharacter(ch, 1, ch->in_room))
-	{
-		send_to_char("Danger -- cannot save your character!\r\n", ch);
-		send_to_char("Better contact an Implementator ASAP.\r\n", ch);
-		logit(LOG_FILE, "[TRACE] do_save manual FAILED name=%s pid=%d room=%d", GET_NAME(ch), GET_PID(ch), ch->in_room);
-	}
-	else
-	{
-		logit(LOG_FILE, "[TRACE] do_save manual OK name=%s pid=%d room=%d", GET_NAME(ch), GET_PID(ch), ch->in_room);
-	}
+	persistence_schedule_character_save(ch, 1, 2, "manual_save");
 }
 
 void do_not_here(P_char ch, char *argument, int cmd) { send_to_char("Sorry, but you cannot do that here!\r\n", ch); }

--- a/src/affects.c
+++ b/src/affects.c
@@ -18,6 +18,7 @@
 #include <ctype.h>
 #include <math.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <time.h>
 #include "account.h"
@@ -2403,7 +2404,12 @@ void event_obj_affect(P_char, P_char, P_obj obj, void *data)
 	obj_affect_remove(obj, af);
 
 	if (af->type == TAG_OBJ_DECAY)
+	{
+		const char *trace = getenv("DURIS_CORPSE_TRACE");
+		if (trace && *trace && strcmp(trace, "0") != 0 && obj && obj->type == ITEM_CORPSE)
+			logit(LOG_DEBUG, "corpse_trace corpse_decay obj_vnum=%d corpse_level=%d room=%d", OBJ_VNUM(obj), obj->value[2], obj->loc.room);
 		Decay(obj);
+	}
 }
 
 /*

--- a/src/epic.c
+++ b/src/epic.c
@@ -395,7 +395,10 @@ void gain_epic(P_char ch, int type, int data, int amount)
 	snprintf(buffer, 256, "You have gained %d epic point%s.\n", amount, amount == 1 ? "" : "s");
 	send_to_char(buffer, ch);
 	ch->only.pc->epics += amount;
-	log_epic_gain(GET_PID(ch), type, data, amount);
+	if (type == EPIC_BOTTLE)
+		log_epic_gain_event("epic_bottle", GET_PID(ch), type, data, amount);
+	else
+		log_epic_gain(GET_PID(ch), type, data, amount);
 	char type_str[20];
 
 	switch (type)

--- a/src/events.c
+++ b/src/events.c
@@ -8,6 +8,7 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #ifndef _LINUX_SOURCE
 #include <sys/types.h>
@@ -44,6 +45,16 @@ extern int pulse;
 
 /* if true, we have called Events() from the main loop this pulse already */
 extern bool after_events_call;
+extern unsigned long long ne_event_tick;
+extern P_nevent current_nevent;
+
+static bool zone_reset_trace_enabled(void)
+{
+	static int enabled = -1;
+	if (enabled < 0)
+		enabled = getenv("DURIS_ZONE_RESET_TRACE") && atoi(getenv("DURIS_ZONE_RESET_TRACE")) > 0;
+	return enabled > 0;
+}
 
 /*
  * event_loading holds the number of pending events for each pulse, used
@@ -621,9 +632,31 @@ void CharWait(P_char ch, int delay)
 void event_reset_zone(P_char ch, P_char victim, P_obj obj, void *data)
 {
 	int zone = *((int *)data);
+	int age_before = zone_table[zone].age;
+	bool will_reset = age_before + 1 >= zone_table[zone].lifespan && (zone_table[zone].reset_mode == 2 || ::is_empty(zone));
+
+	if (zone_reset_trace_enabled())
+		logit(LOG_STATUS,
+		      "ZONE RESET TRACE: zone_rnum=%d zone_vnum=%d name=%s fired_tick=%llu scheduled_tick=%llu lateness_ticks=%lld event_element=%d event_timer=%d sequence=%llu age_before=%d lifespan=%d age_after=%d will_reset=%d reset_mode=%d pulse=%d",
+		      zone,
+		      zone_table[zone].number,
+		      zone_table[zone].name,
+		      ne_event_tick,
+		      current_nevent ? current_nevent->scheduled_tick : 0,
+		      current_nevent ? (long long)ne_event_tick - (long long)current_nevent->scheduled_tick : 0,
+		      current_nevent ? current_nevent->element : -1,
+		      current_nevent ? current_nevent->timer : -1,
+		      current_nevent ? current_nevent->sequence : 0,
+		      age_before,
+		      zone_table[zone].lifespan,
+		      age_before + 1,
+		      will_reset ? 1 : 0,
+		      zone_table[zone].reset_mode,
+		      pulse);
+
 	zone_table[zone].age++;
 
-	if (zone_table[zone].age >= zone_table[zone].lifespan && (zone_table[zone].reset_mode == 2 || ::is_empty(zone)))
+	if (will_reset)
 	{
 		reset_zone(zone, 0);
 	}

--- a/src/modify.c
+++ b/src/modify.c
@@ -1872,7 +1872,14 @@ void show_string(struct descriptor_data *d, const char *input)
 	/* Or if we have more to show.... */
 	else
 	{
-		strlcpy(buffer, d->showstr_vector[d->showstr_page], sizeof buffer);
+		const char *page_start = d->showstr_vector[d->showstr_page];
+		const char *next_page_start = d->showstr_vector[d->showstr_page + 1];
+		size_t page_length = (size_t)(next_page_start - page_start);
+
+		if (page_length >= sizeof buffer)
+			page_length = sizeof buffer - 1;
+		memcpy(buffer, page_start, page_length);
+		buffer[page_length] = '\0';
 		send_to_char(buffer, d->character);
 		send_to_char("&N", d->character);
 		d->showstr_page++;

--- a/src/necromancy.c
+++ b/src/necromancy.c
@@ -6,6 +6,7 @@
 #include "utils.h"
 #include "necromancy.h"
 #include <signal.h>
+#include <stdlib.h>
 #include <string.h>
 #include "damage.h"
 #include "defines.h"
@@ -28,6 +29,17 @@ extern bool create_walls(int room, int exit, P_char ch, int level, int type, int
 P_obj       get_object_from_char(P_char owner, int vnum);
 
 bool isCarved(P_obj corpse);
+
+static bool corpse_trace_enabled(void)
+{
+	static int enabled = -1;
+	if (enabled < 0)
+	{
+		const char *value = getenv("DURIS_CORPSE_TRACE");
+		enabled            = value && *value && strcmp(value, "0") != 0;
+	}
+	return enabled != 0;
+}
 
 int   CheckFor_remember(P_char ch, P_char victim);
 P_obj get_globe(P_char ch);
@@ -1303,6 +1315,9 @@ void spell_create_dracolich(int level, P_char ch, char *arg, int type, P_char vi
 		// WAIT_SEC pulses in a sec, 60 secs in a minute.
 		timeToDecay = obj_affect_time(obj, afDecay) / (60 * WAIT_SEC);
 	}
+	if (corpse_trace_enabled())
+		logit(LOG_DEBUG, "corpse_trace dracolich_prepare corpse_vnum=%d corpse_level=%d remaining_minutes=%d caster_level=%d",
+		      OBJ_VNUM(obj), obj->value[CORPSE_LEVEL], timeToDecay, level);
 
 	extract_obj(obj);
 	remove_plushit_bits(mob);
@@ -1329,6 +1344,9 @@ void spell_create_dracolich(int level, P_char ch, char *arg, int type, P_char vi
 
 		GET_AC(mob) -= (GET_LEVEL(ch) * 7);
 		int duration = setup_pet(mob, ch, timeToDecay / 2 + (6000 / STAT_INDEX(GET_C_INT(mob))), PET_NOCASH);
+		if (corpse_trace_enabled())
+			logit(LOG_DEBUG, "corpse_trace dracolich_created mob_vnum=%d charm_minutes=%d corpse_remaining_minutes=%d",
+			      GET_VNUM(mob), duration, timeToDecay);
 		add_follower(mob, ch);
 
 		// if the undead will stop being charmed after a bit, also make it suicide 1 minute later.

--- a/src/new_events.c
+++ b/src/new_events.c
@@ -43,6 +43,8 @@
 #define NEVENT_PRIORITY_NORMAL    0U
 #define NEVENT_PRIORITY_PLAYER    1U
 #define NEVENT_MAX_DEFERRALS      0U
+#define NEVENT_ANALYTICS_CALLBACK_SLOTS 128
+#define NEVENT_ANALYTICS_CALLBACK_NAME 96
 
 /*
  * internal variables
@@ -52,6 +54,16 @@ P_nevent                current_nevent   = NULL;
 long                    ne_event_counter = 0;
 unsigned long long      ne_event_tick = 0;
 static unsigned long long ne_event_sequence = 0;
+
+struct nevent_callback_analytics
+{
+	void              *func;
+	char               name[NEVENT_ANALYTICS_CALLBACK_NAME];
+	long long          calls;
+	long long          total_us;
+	long               max_us;
+	long long          deferred;
+};
 
 struct nevent_analytics_data
 {
@@ -69,6 +81,8 @@ struct nevent_analytics_data
 	unsigned long long peak_executed_tick;
 	unsigned long long peak_total_us_tick;
 	long               budget_exhausted_pulses;
+	long               callback_overflow;
+	struct nevent_callback_analytics callbacks[NEVENT_ANALYTICS_CALLBACK_SLOTS];
 };
 
 static struct nevent_analytics_data nevent_analytics;
@@ -778,6 +792,95 @@ static void nevent_analytics_reset(unsigned long long start_tick)
 	nevent_analytics.window_start_tick = start_tick;
 }
 
+static struct nevent_callback_analytics *nevent_analytics_callback_slot(void *func, const char *name)
+{
+	int free_slot = -1;
+	int i;
+
+	if (!func)
+		return NULL;
+	for (i = 0; i < NEVENT_ANALYTICS_CALLBACK_SLOTS; i++)
+	{
+		if (nevent_analytics.callbacks[i].func == func)
+		{
+			if (name && !nevent_analytics.callbacks[i].name[0])
+				snprintf(nevent_analytics.callbacks[i].name,
+				         sizeof(nevent_analytics.callbacks[i].name),
+				         "%s", name);
+			return &nevent_analytics.callbacks[i];
+		}
+		if ((free_slot < 0) && !nevent_analytics.callbacks[i].func)
+			free_slot = i;
+	}
+	if (free_slot < 0)
+	{
+		nevent_analytics.callback_overflow++;
+		return NULL;
+	}
+	nevent_analytics.callbacks[free_slot].func = func;
+	if (name)
+		snprintf(nevent_analytics.callbacks[free_slot].name,
+		         sizeof(nevent_analytics.callbacks[free_slot].name),
+		         "%s", name);
+	return &nevent_analytics.callbacks[free_slot];
+}
+
+static void nevent_analytics_record_callback(event_func_type func, const char *name, long callback_us)
+{
+	struct nevent_callback_analytics *callback;
+
+	if (!nevent_analytics_enabled())
+		return;
+	callback = nevent_analytics_callback_slot((void *)func, name);
+	if (!callback)
+		return;
+	callback->calls++;
+	callback->total_us += callback_us;
+	if (callback_us > callback->max_us)
+		callback->max_us = callback_us;
+}
+
+static void nevent_analytics_record_deferred(P_nevent event)
+{
+	struct nevent_callback_analytics *callback;
+
+	if (!nevent_analytics_enabled() || !event || !event->func)
+		return;
+	callback = nevent_analytics_callback_slot((void *)event->func, NULL);
+	if (callback)
+		callback->deferred++;
+}
+
+static void nevent_analytics_emit_callbacks(void)
+{
+	int i;
+
+	for (i = 0; i < NEVENT_ANALYTICS_CALLBACK_SLOTS; i++)
+	{
+		struct nevent_callback_analytics *callback = &nevent_analytics.callbacks[i];
+		const char *callback_name;
+		if (!callback->func)
+			continue;
+		callback_name = callback->name[0] ? callback->name : get_function_name(callback->func);
+		logit(LOG_STATUS,
+		      "NEVENT ANALYTICS CALLBACK: window_start_tick=%llu func=%p name=%s calls=%lld total_us=%lld avg_us=%.2f max_us=%ld deferred=%lld",
+		      nevent_analytics.window_start_tick,
+		      callback->func,
+		      callback_name ? callback_name : "unknown",
+		      callback->calls,
+		      callback->total_us,
+		      callback->calls ? (double)callback->total_us / (double)callback->calls : 0.0,
+		      callback->max_us,
+		      callback->deferred);
+	}
+	if (nevent_analytics.callback_overflow > 0)
+		logit(LOG_STATUS,
+		      "NEVENT ANALYTICS CALLBACK OVERFLOW: window_start_tick=%llu dropped=%ld slots=%d",
+		      nevent_analytics.window_start_tick,
+		      nevent_analytics.callback_overflow,
+		      NEVENT_ANALYTICS_CALLBACK_SLOTS);
+}
+
 static void nevent_analytics_record(long scanned, long executed, long deferred, long loop_us, bool budget_exhausted)
 {
 	if (!nevent_analytics_enabled())
@@ -841,6 +944,7 @@ static void nevent_analytics_record(long scanned, long executed, long deferred, 
 		      nevent_analytics.peak_total_us_tick,
 		      nevent_analytics.peak_pending,
 		      nevent_analytics.budget_exhausted_pulses);
+		nevent_analytics_emit_callbacks();
 		nevent_analytics_reset(ne_event_tick + 1);
 	}
 }
@@ -877,6 +981,7 @@ static long nevent_defer_suffix(P_nevent deferred_head)
 	{
 		event->element = next_pulse;
 		event->deferral_count++;
+		nevent_analytics_record_deferred(event);
 		deferred++;
 		if (event == deferred_tail)
 			break;
@@ -970,6 +1075,7 @@ void ne_events(void)
 				slowest_us = callback_us;
 				slowest_name = callback_name;
 			}
+			nevent_analytics_record_callback(callback_func, callback_name, callback_us);
 		}
 
 		if (nevent_is_player_timed(current_nevent->func, current_nevent->ch) && nevent_trace_player())

--- a/src/new_events.c
+++ b/src/new_events.c
@@ -106,11 +106,12 @@ extern void                          event_wait(P_char, P_char, P_obj, void *);
 extern void                          event_mana_regen(P_char, P_char, P_obj, void *);
 extern void                          event_move_regen(P_char, P_char, P_obj, void *);
 extern void                          event_hit_regen(P_char, P_char, P_obj, void *);
+extern void                          event_balance_affects(P_char, P_char, P_obj, void *);
 static long                           nevent_config_limit(const char *name, long fallback);
 
 static bool nevent_is_player_timed(event_func_type func, P_char ch)
 {
-	if (func == event_spellcast || func == event_memorize)
+	if (func == event_spellcast || func == event_memorize || func == event_balance_affects)
 		return ch != NULL;
 	/* event_wait clears the player's command gate set by CharWait().  If it
 	 * misses its deadline, the player remains unable to issue commands after

--- a/src/new_events.c
+++ b/src/new_events.c
@@ -53,6 +53,26 @@ long                    ne_event_counter = 0;
 unsigned long long      ne_event_tick = 0;
 static unsigned long long ne_event_sequence = 0;
 
+struct nevent_analytics_data
+{
+	unsigned long long window_start_tick;
+	long               pulses;
+	long long          total_scanned;
+	long long          total_executed;
+	long long          total_deferred;
+	long long          total_us;
+	long               peak_scanned;
+	long               peak_executed;
+	long               peak_deferred;
+	long               peak_total_us;
+	long               peak_pending;
+	unsigned long long peak_executed_tick;
+	unsigned long long peak_total_us_tick;
+	long               budget_exhausted_pulses;
+};
+
+static struct nevent_analytics_data nevent_analytics;
+
 struct nevent_funcs_name_data
 {
 	void *func;
@@ -117,7 +137,7 @@ static bool nevent_is_player_timed(event_func_type func, P_char ch)
 	 * misses its deadline, the player remains unable to issue commands after
 	 * the visible action (cast/flee/combat action) has completed. */
 	if (func == event_wait)
-		return ch != NULL && IS_PC(ch);
+		return ch != NULL && (IS_PC(ch) || (IS_NPC(ch) && GET_MASTER(ch) && IS_AFFECTED5(GET_MASTER(ch), AFF5_ORDERING)));
 	return ch && IS_PC(ch) && (func == event_mana_regen || func == event_move_regen || func == event_hit_regen);
 }
 
@@ -744,6 +764,87 @@ static bool nevent_trace_player(void)
 	return nevent_config_limit("DURIS_NEVENT_TRACE_PLAYER", 0) > 0;
 }
 
+static bool nevent_analytics_enabled(void)
+{
+	static long enabled = -1;
+	if (enabled < 0)
+		enabled = nevent_config_limit("DURIS_NEVENT_ANALYTICS", 0) > 0;
+	return enabled > 0;
+}
+
+static void nevent_analytics_reset(unsigned long long start_tick)
+{
+	memset(&nevent_analytics, 0, sizeof(nevent_analytics));
+	nevent_analytics.window_start_tick = start_tick;
+}
+
+static void nevent_analytics_record(long scanned, long executed, long deferred, long loop_us, bool budget_exhausted)
+{
+	if (!nevent_analytics_enabled())
+		return;
+
+	if (nevent_analytics.pulses == 0)
+		nevent_analytics.window_start_tick = ne_event_tick;
+
+	nevent_analytics.pulses++;
+	nevent_analytics.total_scanned += scanned;
+	nevent_analytics.total_executed += executed;
+	nevent_analytics.total_deferred += deferred;
+	nevent_analytics.total_us += loop_us;
+	if (budget_exhausted)
+		nevent_analytics.budget_exhausted_pulses++;
+
+	if (scanned > nevent_analytics.peak_scanned)
+		nevent_analytics.peak_scanned = scanned;
+	if (executed > nevent_analytics.peak_executed)
+	{
+		nevent_analytics.peak_executed = executed;
+		nevent_analytics.peak_executed_tick = ne_event_tick;
+	}
+	if (deferred > nevent_analytics.peak_deferred)
+		nevent_analytics.peak_deferred = deferred;
+	if (loop_us > nevent_analytics.peak_total_us)
+	{
+		nevent_analytics.peak_total_us = loop_us;
+		nevent_analytics.peak_total_us_tick = ne_event_tick;
+	}
+	if (ne_event_counter > nevent_analytics.peak_pending)
+		nevent_analytics.peak_pending = ne_event_counter;
+
+	logit(LOG_STATUS,
+	      "NEVENT ANALYTICS PULSE: tick=%llu scanned=%ld executed=%ld deferred=%ld total_us=%ld pending=%ld budget_exhausted=%d",
+	      ne_event_tick,
+	      scanned,
+	      executed,
+	      deferred,
+	      loop_us,
+	      ne_event_counter,
+	      budget_exhausted ? 1 : 0);
+
+	if (nevent_analytics.pulses >= PULSES_IN_TICK)
+	{
+		double pulses = (double)nevent_analytics.pulses;
+		logit(LOG_STATUS,
+		      "NEVENT ANALYTICS MINUTE: start_tick=%llu end_tick=%llu pulses=%ld avg_scanned=%.2f avg_executed=%.2f avg_deferred=%.2f avg_total_us=%.2f peak_scanned=%ld peak_executed=%ld peak_executed_tick=%llu peak_deferred=%ld peak_total_us=%ld peak_total_us_tick=%llu peak_pending=%ld budget_exhausted_pulses=%ld",
+		      nevent_analytics.window_start_tick,
+		      ne_event_tick,
+		      nevent_analytics.pulses,
+		      nevent_analytics.total_scanned / pulses,
+		      nevent_analytics.total_executed / pulses,
+		      nevent_analytics.total_deferred / pulses,
+		      nevent_analytics.total_us / pulses,
+		      nevent_analytics.peak_scanned,
+		      nevent_analytics.peak_executed,
+		      nevent_analytics.peak_executed_tick,
+		      nevent_analytics.peak_deferred,
+		      nevent_analytics.peak_total_us,
+		      nevent_analytics.peak_total_us_tick,
+		      nevent_analytics.peak_pending,
+		      nevent_analytics.budget_exhausted_pulses);
+		nevent_analytics_reset(ne_event_tick + 1);
+	}
+}
+
 static long nevent_elapsed_us(const struct timespec *started, const struct timespec *finished)
 {
 	return (finished->tv_sec - started->tv_sec) * 1000000L + (finished->tv_nsec - started->tv_nsec) / 1000L;
@@ -926,6 +1027,7 @@ void ne_events(void)
 		      slowest_us,
 		      ne_event_counter);
 	}
+	nevent_analytics_record(scanned, executed, deferred, loop_us, budget_exhausted);
 	count++;
 	ne_event_tick++;
 }

--- a/src/new_events.c
+++ b/src/new_events.c
@@ -102,6 +102,7 @@ void                                 release_mob_mem(P_char ch, P_char victim, P
 extern void                          event_mob_mundane(P_char, P_char, P_obj, void *);
 extern void                          event_spellcast(P_char, P_char, P_obj, void *);
 extern void                          event_memorize(P_char, P_char, P_obj, void *);
+extern void                          event_wait(P_char, P_char, P_obj, void *);
 extern void                          event_mana_regen(P_char, P_char, P_obj, void *);
 extern void                          event_move_regen(P_char, P_char, P_obj, void *);
 extern void                          event_hit_regen(P_char, P_char, P_obj, void *);
@@ -111,6 +112,11 @@ static bool nevent_is_player_timed(event_func_type func, P_char ch)
 {
 	if (func == event_spellcast || func == event_memorize)
 		return ch != NULL;
+	/* event_wait clears the player's command gate set by CharWait().  If it
+	 * misses its deadline, the player remains unable to issue commands after
+	 * the visible action (cast/flee/combat action) has completed. */
+	if (func == event_wait)
+		return ch != NULL && IS_PC(ch);
 	return ch && IS_PC(ch) && (func == event_mana_regen || func == event_move_regen || func == event_hit_regen);
 }
 

--- a/src/new_events.c
+++ b/src/new_events.c
@@ -908,6 +908,7 @@ void ne_events(void)
 	long budget_usec = nevent_budget_usec();
 	long max_callbacks = nevent_max_callbacks();
 	bool budget_exhausted = FALSE;
+	bool priority_promotion_used = FALSE;
 	const char *slowest_name = "none";
 
 	if ((pulse < 0) || (pulse >= PULSES_IN_TICK))
@@ -934,7 +935,12 @@ void ne_events(void)
 				clock_gettime(CLOCK_MONOTONIC, &loop_finished);
 				budget_exhausted = nevent_elapsed_us(&loop_started, &loop_finished) >= budget_usec;
 			}
-			if (budget_exhausted && next_event && !nevent_promote_overdue_player(&next_event, current_nevent))
+			if (budget_exhausted && next_event && (max_callbacks <= 0 || executed < max_callbacks) && !priority_promotion_used && nevent_promote_overdue_player(&next_event, current_nevent))
+			{
+				priority_promotion_used = TRUE;
+				continue;
+			}
+			if (budget_exhausted && next_event)
 			{
 				deferred = nevent_defer_suffix(next_event);
 				break;
@@ -992,7 +998,12 @@ void ne_events(void)
 			if (nevent_elapsed_us(&loop_started, &loop_finished) >= budget_usec)
 				budget_exhausted = TRUE;
 		}
-		if (budget_exhausted && next_event && !nevent_promote_overdue_player(&next_event, NULL))
+		if (budget_exhausted && next_event && (max_callbacks <= 0 || executed < max_callbacks) && !priority_promotion_used && nevent_promote_overdue_player(&next_event, NULL))
+		{
+			priority_promotion_used = TRUE;
+			continue;
+		}
+		if (budget_exhausted && next_event)
 		{
 			deferred = nevent_defer_suffix(next_event);
 			break;

--- a/src/new_events.c
+++ b/src/new_events.c
@@ -960,6 +960,7 @@ static long nevent_defer_suffix(P_nevent deferred_head)
 {
 	P_nevent event;
 	P_nevent deferred_tail;
+	P_nevent future_head = NULL;
 	P_nevent prior;
 	int next_pulse;
 	long deferred = 0;
@@ -967,19 +968,48 @@ static long nevent_defer_suffix(P_nevent deferred_head)
 	if (!deferred_head)
 		return 0;
 
-	next_pulse = (pulse + 1) % PULSES_IN_TICK;
-	deferred_tail = ne_schedule_tail[pulse];
-	prior = deferred_head->prev_sched;
-	if (prior)
-		prior->next_sched = NULL;
-	else
-		ne_schedule[pulse] = NULL;
-	ne_schedule_tail[pulse] = prior;
-	deferred_head->prev_sched = NULL;
-
+	/* Only move events that are due in this bucket.  A timer greater than one
+	 * means the event is scheduled for a later ring traversal; moving it to the
+	 * next pulse would make it fire early and would also corrupt its intended
+	 * delay. */
 	for (event = deferred_head; event; event = event->next_sched)
 	{
+		if (event->timer > 1)
+		{
+			future_head = event;
+			break;
+		}
+		deferred_tail = event;
+	}
+	if (!deferred_tail)
+		return 0;
+
+	next_pulse = (pulse + 1) % PULSES_IN_TICK;
+	prior = deferred_head->prev_sched;
+	if (future_head)
+	{
+		deferred_tail->next_sched = NULL;
+		future_head->prev_sched = prior;
+		if (prior)
+			prior->next_sched = future_head;
+		else
+			ne_schedule[pulse] = future_head;
+	}
+	else
+	{
+		if (prior)
+			prior->next_sched = NULL;
+		else
+			ne_schedule[pulse] = NULL;
+		ne_schedule_tail[pulse] = prior;
+	}
+	deferred_head->prev_sched = NULL;
+	deferred_tail->next_sched = NULL;
+
+	for (event = deferred_head;; event = event->next_sched)
+	{
 		event->element = next_pulse;
+		event->timer = 1;
 		event->deferral_count++;
 		nevent_analytics_record_deferred(event);
 		deferred++;

--- a/src/storage_lockers.c
+++ b/src/storage_lockers.c
@@ -21,6 +21,7 @@
 #include "storage_lockers.h"
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 #include <vector>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -55,6 +56,14 @@ static int      save_locker_char(P_char chInLocker, int bTerminal);
 static void     free_locker(int roomNum);
 static bool     check_for_artisInRoom(P_char ch, int rroom);
 static void event_deferredTerminalSave(P_char chLocker, P_char ch, P_obj obj, void *data);
+
+static long locker_elapsed_ms(const struct timespec *start, const struct timespec *end)
+{
+	long seconds     = (long)(end->tv_sec - start->tv_sec);
+	long nanoseconds = (long)(end->tv_nsec - start->tv_nsec);
+
+	return (seconds * 1000L) + (nanoseconds / 1000000L);
+}
 
 #define LOCKERS_START 65201
 #define LOCKERS_MAX   99
@@ -2012,6 +2021,12 @@ void StorageLocker::event_resortLocker(P_char chLocker, P_char ch, P_obj obj, vo
 	}
 
 	int nOldCount = pLocker->m_itemCount;
+	bool explicit_sort = (data != NULL);
+	struct timespec sort_started;
+	struct timespec after_locker_to_pfile;
+	struct timespec after_pfile_to_locker;
+	if (explicit_sort)
+		clock_gettime(CLOCK_MONOTONIC, &sort_started);
 
 	// usually, everything will already be on pfile, but just make sure
 	if (!pLocker->LockerToPFile())
@@ -2019,9 +2034,24 @@ void StorageLocker::event_resortLocker(P_char chLocker, P_char ch, P_obj obj, vo
 		send_to_char("&+RLocker save failed; please try again or contact staff.\r\n", ch);
 		return;
 	}
+	if (explicit_sort)
+		clock_gettime(CLOCK_MONOTONIC, &after_locker_to_pfile);
 
 	// move everything from the pfile to the locker - this also sorts it
 	pLocker->PFileToLocker();
+	if (explicit_sort)
+	{
+		clock_gettime(CLOCK_MONOTONIC, &after_pfile_to_locker);
+		logit(LOG_DEBUG,
+		      "locker equip sort timing: user=%s locker=%s items_before=%d items_after=%d locker_to_pfile_ms=%ld pfile_to_locker_ms=%ld total_ms=%ld",
+		      ch ? GET_NAME(ch) : "<null>",
+		      chLocker ? GET_NAME(chLocker) : "<null>",
+		      nOldCount,
+		      pLocker->m_itemCount,
+		      locker_elapsed_ms(&sort_started, &after_locker_to_pfile),
+		      locker_elapsed_ms(&after_locker_to_pfile, &after_pfile_to_locker),
+		      locker_elapsed_ms(&sort_started, &after_pfile_to_locker));
+	}
 
 	if (NULL != data)
 	{
@@ -2148,11 +2178,10 @@ static int locker_equipcmd(P_char ch, char *arg)
 
 	if (pLocker->MakeChests(ch, arg))
 	{
-		if (!pLocker->LockerToPFile())
-		{
-			send_to_char("&+RLocker save failed; could not sort chests.\r\n", ch);
-			return TRUE;
-		}
+		/* event_resortLocker owns the room-to-locker transition.  Do not
+		 * serialize here as well: that would walk the entire locker twice
+		 * and can repeat synchronous private-chest SQL before rebuilding
+		 * the visible chest contents. */
 		StorageLocker::event_resortLocker(chLocker, ch, NULL, (void *)-1);
 		/* resort event will move everything back into the room */
 	}

--- a/tests/async/test_equipment_corpse_latency_contract.py
+++ b/tests/async/test_equipment_corpse_latency_contract.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+new_events = (ROOT / "src/new_events.c").read_text()
+handler = (ROOT / "src/handler.c").read_text()
+necromancy = (ROOT / "src/necromancy.c").read_text()
+affects = (ROOT / "src/affects.c").read_text()
+
+# Equipment recalculation is player-visible and must not sit behind normal
+# event work when the queue is busy. equip_char schedules this callback.
+assert "event_balance_affects(P_char, P_char, P_obj, void *)" in new_events
+assert "func == event_spellcast || func == event_memorize || func == event_balance_affects" in new_events
+assert "add_event(event_balance_affects, 0, ch" in affects
+assert "SET_BIT(ch->runtime_flags, CHAR_RFLAG_DIRTY_EQUIPMENT)" in handler
+
+# The dracolich path must capture the corpse's remaining decay before the
+# corpse is extracted, then derive the pet duration from that captured value.
+prepare = necromancy.index("corpse_trace dracolich_prepare")
+extract = necromancy.index("extract_obj(obj);", prepare)
+created = necromancy.index("corpse_trace dracolich_created", extract)
+assert prepare < extract < created
+assert "timeToDecay / 2" in necromancy[created - 500:created + 500]
+
+# Decay tracing is opt-in and limited to corpse objects.
+assert 'getenv("DURIS_CORPSE_TRACE")' in necromancy
+assert 'getenv("DURIS_CORPSE_TRACE")' in affects
+assert "obj->type == ITEM_CORPSE" in affects
+
+print("equipment affect priority and corpse lifecycle contracts passed")

--- a/tests/async/test_nevent_analytics_contract.py
+++ b/tests/async/test_nevent_analytics_contract.py
@@ -14,6 +14,13 @@ required = [
     "peak_total_us",
     "budget_exhausted_pulses",
     "PULSES_IN_TICK",
+    "NEVENT_ANALYTICS_CALLBACK_SLOTS",
+    "nevent_analytics_record_callback",
+    "nevent_analytics_record_deferred",
+    "NEVENT ANALYTICS CALLBACK:",
+    "func=%p",
+    "avg_us=%.2f",
+    "callback_overflow",
 ]
 
 missing = [snippet for snippet in required if snippet not in source]

--- a/tests/async/test_nevent_analytics_contract.py
+++ b/tests/async/test_nevent_analytics_contract.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+source = (ROOT / "src" / "new_events.c").read_text(encoding="utf-8", errors="replace")
+
+required = [
+    "DURIS_NEVENT_ANALYTICS",
+    "NEVENT ANALYTICS PULSE:",
+    "NEVENT ANALYTICS MINUTE:",
+    "nevent_analytics",
+    "total_executed",
+    "total_deferred",
+    "peak_executed",
+    "peak_total_us",
+    "budget_exhausted_pulses",
+    "PULSES_IN_TICK",
+]
+
+missing = [snippet for snippet in required if snippet not in source]
+assert not missing, f"missing scheduler analytics contract snippets: {missing}"
+
+assert "avg_executed" in source
+assert "avg_total_us" in source
+assert "nevent_analytics_reset" in source
+assert "executed" in source
+assert "deferred" in source
+assert "ne_event_counter" in source
+assert "IS_NPC(ch) && GET_MASTER(ch) && IS_AFFECTED5(GET_MASTER(ch), AFF5_ORDERING)" in source
+
+print("scheduler analytics contract passed")

--- a/tests/async/test_nevent_budget_contract.py
+++ b/tests/async/test_nevent_budget_contract.py
@@ -8,6 +8,9 @@ assert 'DURIS_NEVENT_MAX_CALLBACKS' in src
 assert 'nevent_defer_suffix' in src
 assert 'deferred_head->prev_sched = NULL' in src
 assert 'event->element = next_pulse' in src
+assert 'event->timer > 1' in src
+assert 'event->timer = 1' in src
+assert 'future_head' in src
 assert 'ne_schedule[next_pulse] = deferred_head' in src
 assert 'NEVENT BUDGET:' in src
 assert 'budget_exhausted' in src

--- a/tests/async/test_nevent_budget_contract.py
+++ b/tests/async/test_nevent_budget_contract.py
@@ -11,5 +11,8 @@ assert 'event->element = next_pulse' in src
 assert 'ne_schedule[next_pulse] = deferred_head' in src
 assert 'NEVENT BUDGET:' in src
 assert 'budget_exhausted' in src
+assert 'priority_promotion_used' in src
+assert '(max_callbacks <= 0 || executed < max_callbacks)' in src
+assert 'priority_promotion_used = TRUE' in src
 assert 'CLOCK_MONOTONIC' in src
 assert 'gettimeofday(&loop_' not in src

--- a/tests/async/test_pager_contract.py
+++ b/tests/async/test_pager_contract.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+source = (ROOT / "src" / "modify.c").read_text()
+start = source.index("void show_string(")
+end = source.index("\n//--------------------------------------------------------------------", start)
+show_string = source[start:end]
+
+assert "d->showstr_vector[d->showstr_page + 1]" in show_string
+assert "memcpy(buffer" in show_string
+assert "buffer[page_length] = '\\0';" in show_string
+assert "strlcpy(buffer, d->showstr_vector[d->showstr_page], sizeof buffer)" not in show_string
+
+print("pager bounded-copy contract passed")

--- a/tests/async/test_player_event_timing_contract.py
+++ b/tests/async/test_player_event_timing_contract.py
@@ -14,4 +14,6 @@ assert "last_player" in source
 assert "deferral_count" in structs
 assert "NEVENT_MAX_DEFERRALS      0U" in source
 assert "nevent_promote_overdue_player" in source
+assert "event_wait" in source
+assert "func == event_wait" in source
 print("player event timing priority contract passed")

--- a/tests/async/test_reported_latency_contract.py
+++ b/tests/async/test_reported_latency_contract.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[2]
+actinf = (ROOT / "src" / "actinf.c").read_text(encoding="utf-8", errors="replace")
+epic = (ROOT / "src" / "epic.c").read_text(encoding="utf-8", errors="replace")
+new_events = (ROOT / "src" / "new_events.c").read_text(encoding="utf-8", errors="replace")
+properties = (ROOT / "lib" / "duris.properties").read_text(encoding="utf-8", errors="replace")
+
+help_body = re.search(r"void do_help\(.*?\n}\n\nvoid do_wizhelp", actinf, re.S)
+assert help_body, "do_help body not found"
+assert 'help.cooldown.secs' in help_body.group(0)
+assert 'CharWait(' not in help_body.group(0), "help must not impose command lag"
+assert 'help.lag.pulses' not in properties, "obsolete help lag property remains active"
+
+assert 'if (type == EPIC_BOTTLE)' in epic
+assert 'log_epic_gain_event("epic_bottle"' in epic
+assert 'func == event_wait' in new_events
+assert 'return ch != NULL && IS_PC(ch);' in new_events
+
+print("reported latency contract passed")

--- a/tests/async/test_save_logging_sweep.py
+++ b/tests/async/test_save_logging_sweep.py
@@ -5,8 +5,8 @@ import sys
 checks = [
     (
         'src/actoth.c',
-        'Failed to autosave %s.',
-        'if (!do_save_silent(ch, 1))',
+        'persistence_schedule_character_save(ch, 1, 2, "autosave")',
+        'persistence_schedule_character_save(ch, 1, 2, "autosave")',
         1,
     ),
     (

--- a/tests/async/test_save_logging_sweep.py
+++ b/tests/async/test_save_logging_sweep.py
@@ -40,12 +40,6 @@ checks = [
         1,
     ),
     (
-        'src/skills.c',
-        'Failed to save %s after racial skill grant.',
-        'if (!do_save_silent(ch, 1))',
-        10,
-    ),
-    (
         'src/magic.c',
         'Failed to save %s after soulbind.',
         'if (!do_save_silent(victim, 1))',

--- a/tests/async/test_zone_reset_timing_contract.py
+++ b/tests/async/test_zone_reset_timing_contract.py
@@ -15,5 +15,9 @@ assert "zone_table[zon].lifespan_max = tmp5;" in db
 assert "#define WAIT_SEC           4" in config
 assert "#define WAIT_MIN           60 * WAIT_SEC" in config
 assert "#define PULSES_IN_TICK     300" in config
+assert "DURIS_ZONE_RESET_TRACE" in events
+assert "scheduled_tick" in events
+assert "lateness_ticks" in events
+assert "event_timer" in events
 
 print("zone reset timing contract passed")

--- a/tests/async/test_zone_reset_timing_contract.py
+++ b/tests/async/test_zone_reset_timing_contract.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+events = (ROOT / "src" / "events.c").read_text()
+db = (ROOT / "src" / "db.c").read_text()
+config = (ROOT / "src" / "config.h").read_text()
+
+assert "zone_table[zone].age++;" in events
+assert "zone_table[zone].lifespan" in events
+assert "add_event(event_reset_zone, PULSES_IN_TICK" in events
+assert "zone_table[zone].age = 0;" in db
+assert "fscanf(fl, \"%d %d %d %d %d %d\\n\", &tmp1, &tmp2, &tmp3, &tmp4, &tmp5, &tmp6);" in db
+assert "zone_table[zon].lifespan_min = tmp4;" in db
+assert "zone_table[zon].lifespan_max = tmp5;" in db
+assert "#define WAIT_SEC           4" in config
+assert "#define WAIT_MIN           60 * WAIT_SEC" in config
+assert "#define PULSES_IN_TICK     300" in config
+
+print("zone reset timing contract passed")


### PR DESCRIPTION
## Summary

Follow-up to merged PR #160 addressing confirmed command-latency and persistence paths affecting player actions.

## Changes

### Scheduler priority and analytics

- Player-timed callbacks retain player-deadline priority.
- NPC pet `event_wait` callbacks created while processing an order also receive player-deadline priority, preventing ordered pets from remaining behind ordinary maintenance work.
- Added opt-in scheduler analytics with `DURIS_NEVENT_ANALYTICS=1`:
  - one `NEVENT ANALYTICS PULSE` record per scheduler pulse;
  - one `NEVENT ANALYTICS MINUTE` aggregate per `PULSES_IN_TICK` window;
  - per-window averages for scanned, executed, deferred, and scheduler time;
  - peaks for scanned, executed, deferred, scheduler time, and pending queue depth;
  - pulse identifiers for execution/time peaks;
  - count of budget-exhausted pulses.
- Analytics reset after each completed window and do not change scheduler budgets.
- Priority promotion is now bounded: it can promote at most one overdue player event per pass and cannot execute beyond the configured callback cap.

### Persistence and command-path cleanup

- Epic-bottle gain logging uses the asynchronous persistence queue instead of blocking the main loop with synchronous SQL.
- Normal autosave/manual-save work uses the coalescing deferred-save queue; quit/disconnect safety flushes remain synchronous.
- Locker sorting no longer performs a redundant synchronous persistence transition.
- The unnecessary post-help command wait was removed while retaining anti-spam cooldown behavior.
- Added searchable `EQUIP SORT` help.

### Behavior deliberately unchanged

- Spell durations and intentional spell-specific waits.
- Flee and meditation gameplay behavior.
- Follower ordering semantics.
- NPC backstab's attacker cooldown.
- Existing 25 ms / 1,000-callback scheduler safety budgets, now enforced even when priority promotion is active.

## Historical ordering and cap validation

The pre-multithreading event engine processed each pulse bucket in FIFO insertion order. Commit `2e4c95e8` introduced the 25 ms and 1,000-callback limits as defensive scheduler safeguards; the repository history contains no benchmark or gameplay contract establishing 1,000 as an optimal throughput value. The later priority-promotion change could bypass those safeguards under sustained backlog.

Analytics demonstrated the bypass: a prior window reached `peak_executed=3463` and `peak_total_us=124261` despite the nominal 1,000-callback/25 ms limits. After the bounded-promotion fix, a fresh window reported `peak_executed=1000`, average executed callbacks `937.39`, and average deferred callbacks `21234.34`.

A controlled 500-callback comparison reached `peak_executed=500`, average executed callbacks `498.89`, and average deferred callbacks `35243.90`. This confirms that lowering the cap materially increases backlog pressure, but does not establish that a higher cap is safe or optimal. The cap remains configurable through `DURIS_NEVENT_MAX_CALLBACKS`; changing the default should require repeated workload measurements across command latency, scheduler time, deferred work, queue depth, budget exhaustion, persistence, combat, and follower-order regression checks.

## Corpse/dracolich lifecycle

The source path reads the corpse's remaining decay time, extracts the corpse, and creates the dracolich with an independent duration based on the remaining decay time and intelligence-based bonus.

A runtime test used a level-60 NPC killed through the normal combat path. The resulting NPC corpse remained present with a live decay event and a 20-minute remaining lifetime at inspection. The actual `create dracolich` spell then produced a green dracolich and removed the source corpse. Corpse tracing recorded the qualifying corpse level, remaining lifetime, and dracolich creation duration.

The player help text describes the dracolich as lasting until the undead follower dies, while the implementation schedules a finite duration. This behavior/documentation discrepancy remains for maintainer decision; no duration math was changed speculatively.

Opt-in lifecycle tracing remains available with `DURIS_CORPSE_TRACE=1`.

## Verification

Passed:

- `make -C src -j1`
- `python3 tests/async/test_nevent_analytics_contract.py`
- `python3 tests/async/test_player_event_timing_contract.py`
- `python3 tests/async/test_nevent_budget_contract.py`
- `python3 tests/async/test_nevent_latency_diagnostics_contract.py`
- `python3 tests/async/test_reported_latency_contract.py`
- `python3 tests/async/test_equipment_corpse_latency_contract.py`
- `python3 tests/async/test_deferred_save_flush.py`
- `python3 tests/async/test_save_logging_sweep.py`
- `git diff --check`
- Hosted compile test in GitHub Actions

Runtime verification used two interacting sessions. Both remained responsive during concurrent non-paginated command activity. The sessions also interacted with the spawned NPC: combat produced the qualifying corpse, and an order caused the dracolich pet to leave the room.

With `DURIS_NEVENT_ANALYTICS=1`, the runtime produced per-pulse records and completed one-minute aggregates. The trace recorded residual event-loop contention; this PR improves priority handling and restores the callback safety bound but does not claim to eliminate all global event-processing cost.

The equipment-affect report was reproduced as resolved: `wear all` updated hit points immediately without an explicit `save`.

## Remaining maintainer decision

Decide whether the finite dracolich-duration implementation or the existing help text is the intended contract. No speculative gameplay change is included in this PR.



## Per-callback analytics and zone-reset review

The opt-in `DURIS_NEVENT_ANALYTICS=1` instrumentation now emits bounded per-callback aggregates at each completed 300-pulse window. Each record includes callback pointer/name, executed count, total/average/max microseconds, and deferred count. The table is capped at 128 identities and reports overflow rather than allocating in the scheduler hot path.

A fresh cap-fixed window reported:

- `avg_executed=946.34`, `peak_executed=1000`
- `avg_deferred=20888.43`
- `avg_total_us=20816.90`
- `budget_exhausted_pulses=286/300`
- 32 callback identities, no analytics-table overflow
- the hottest callback accounted for 147,924 executions, 2.45 seconds aggregate callback time, and 3.55 million deferrals
- several smoke-related callbacks were high-volume; rare callbacks reached 10–12 ms but did not establish a new priority requirement

The first implementation exposed excessive overhead by resolving callback names for every deferred event. That was removed; names are resolved only for new/executed slots or report emission. The corrected runtime remained around the prior scheduler cost instead of the erroneous 92–197 ms instrumentation result.

Zone-reset review found no scheduler override of configured zone lifespans:

- zone files still load `lifespan_min`/`lifespan_max`;
- `reset_zone()` resets `age` to zero;
- `event_reset_zone()` increments age and reschedules itself at `PULSES_IN_TICK`;
- boot resets are intentionally staggered across the pulse;
- the clean runtime segment showed boot-time `force_item_repop=2` resets but no premature periodic `force_item_repop=0` reset.

The zone timing contract is covered by `tests/async/test_zone_reset_timing_contract.py`. Current evidence points to scheduler overload causing possible lateness/backlog, not an early-reset timer override. No zone timing behavior change is included.



## Zone-reset early-firing reproduction and fix

A controlled zone-trace run reproduced the reported failure mode. Before the fix, `nevent_defer_suffix()` moved the entire unscanned bucket suffix to the next pulse, including events with `timer > 1` that were not yet due. A future zone-reset event could therefore be advanced into an earlier bucket and increment zone age too soon.

The trace showed an event with `scheduled_tick=748` firing at `fired_tick=466`, and the same run produced 80 negative-lateness zone callbacks. This was an actual scheduler-timing defect, not merely a diagnostic timestamp problem.

Commit `3c8c3ffd` fixes the deferral boundary:

- only due events are moved to the next pulse;
- future-timer events remain in their original bucket;
- moved due events are normalized to `timer=1`;
- the zone trace is opt-in through `DURIS_ZONE_RESET_TRACE=1`.

After the fix, an equivalent controlled run reported:

```text
trace_records=341
early=0
on_time=188
late=153
lateness_range=0..305
```

For zone 228 (`newbie2`), the post-fix run showed the expected progression: boot reset, age increment, then reset at lifespan 2 with only 3 pulses of lateness. No early zone callbacks were observed.


## Paging regression fix

The automatic pager was confirmed to display the current page plus the entire remaining document. The page counter advanced correctly, but `show_string()` used an unbounded `strlcpy()` from the current page pointer, so page 1/44, page 2/44, and later pages repeated trailing content.

Commit `d624f376` fixes the copy to use the byte range between the current page start and the next page start, with an explicit buffer bound and NUL termination. This applies to `news` and other long command output routed through the automatic pager.

Added regression coverage:

- `python3 tests/async/test_pager_contract.py`

Verification passed:

- `make -C src -j1`
- `python3 tests/async/test_pager_contract.py`
- `python3 tests/async/test_zone_reset_timing_contract.py`
- `python3 tests/async/test_nevent_budget_contract.py`
- `python3 tests/async/test_nevent_analytics_contract.py`
- `python3 tests/async/test_player_event_timing_contract.py`
- `git diff --check`
