### PR TITLE
fast mode (no tick delays)

### DIFF
--- a/src/actinf.c
+++ b/src/actinf.c
@@ -3560,7 +3560,7 @@ void do_world(P_char ch, char *argument, int cmd)
 	switch (world_values[world_index])
 	{
 		case WORLD_STATS:
-			ct                           = time(0);
+			ct                           = get_time();
 			tmstr                        = asctime(localtime(&ct));
 			*(tmstr + strlen(tmstr) - 1) = '\0';
 			snprintf(buf, MAX_STRING_LENGTH, "Current time is: %s (GMT)\n", tmstr);
@@ -5202,7 +5202,7 @@ void do_score(P_char ch, char *argument, int cmd)
 		}
 		else
 		{
-			ct    = time(0);
+			ct    = get_time();
 			timer = real_time_countdown(ct, af->modifier, 60 * 60 * 24 * 2);
 			snprintf(buf,
 			         MAX_STRING_LENGTH,
@@ -5516,6 +5516,9 @@ void do_score(P_char ch, char *argument, int cmd)
 	send_to_char("\n", ch);
 }
 
+extern int fast;
+extern time_t vtime, vtime0;
+
 void do_time(P_char ch, char *argument, int cmd)
 {
 	char                 *tmstr;
@@ -5575,7 +5578,7 @@ void do_time(P_char ch, char *argument, int cmd)
 	snprintf(Gbuf2, MAX_STRING_LENGTH, "The %d%s Day of the %s, Year %d.\n", day, suf, month_name[time_info.month], (time_info.year + 1000));
 	send_to_char(Gbuf2, ch);
 
-	ct     = time(0);
+	ct     = get_time();
 	uptime = real_time_passed(ct, boot_time);
 
 	// Auto Reboot - Drannak
@@ -5586,7 +5589,7 @@ void do_time(P_char ch, char *argument, int cmd)
 	if ((uptime.day * 24 + uptime.hour) > autoreboot_threshold_hours)
 	{
 		// If no shutdown in progress, or shutdown is > delay minutes out.
-		if (shutdownData.reboot_time == 0 || shutdownData.reboot_time - time(NULL) > autoreboot_delay_minutes * 60)
+		if (shutdownData.reboot_time == 0 || shutdownData.reboot_time - get_time() > autoreboot_delay_minutes * 60)
 		{
 			char shutdown_cmd[100];
 			snprintf(shutdown_cmd, 100, "autoreboot %d", autoreboot_delay_minutes);
@@ -5619,9 +5622,16 @@ void do_time(P_char ch, char *argument, int cmd)
 
 	if (IS_TRUSTED(ch))
 	{
-		snprintf(Gbuf2, MAX_STRING_LENGTH, "Kvark time&n: %ld \n", time(NULL));
+		snprintf(Gbuf2, MAX_STRING_LENGTH, "Kvark time&n: %ld \n", get_time());
 		send_to_char(Gbuf2, ch);
 	}
+
+	if (fast && time(0) != vtime0)
+	{
+		send_to_char_f(ch, "&+YFAST&n mode: &+W%.3f&+wx&n\n",
+			(vtime - vtime0) / (float)(time(0) - vtime0));
+	}
+
 	displayShutdownMsg(ch);
 }
 
@@ -7875,7 +7885,7 @@ void do_ok(P_char ch, char *arg, int cmd)
 	while (isspace(*arg))
 		arg++;
 
-	t = time(0);
+	t = get_time();
 
 	snprintf(Gbuf1, MAX_INPUT_LENGTH, "%s accepted - %s : %s", GET_NAME(t_ch), arg, ctime(&t));
 
@@ -7948,7 +7958,7 @@ void do_punish(P_char ch, char *arg, int cmd)
 		clear_title(t_ch);
 		return;
 	}
-	t = time(0);
+	t = get_time();
 	// Note: ctime contains a carriage return, so nothing after it.
 	snprintf(Gbuf1, MAX_STRING_LENGTH, "&+W%s &+Lpunished&+W %d level%s for: %s -  %s", GET_NAME(t_ch), i, (i > 1) ? "s" : "", arg, ctime(&t));
 
@@ -8055,7 +8065,7 @@ void do_artireset(P_char ch, char *arg, int cmd)
 		}
 
 		//    UpdateArtiBlood(ch, tmp_object, 100);
-		tmp_object->timer[3] = time(NULL);
+		tmp_object->timer[3] = get_time();
 		act("$p is reset.", FALSE, ch, tmp_object, 0, TO_CHAR);
 		tmp_object->value[7] = number(4, 7);
 		wizlog(GET_LEVEL(ch), "%s reset artifact '%s' in [%d]", GET_NAME(ch), tmp_object->short_description, world[ch->in_room].number);
@@ -8447,7 +8457,7 @@ void web_info(void)
 
 	strcat(Gbuf3, Gbuf2);
 
-	ct     = time(0);
+	ct     = get_time();
 	uptime = real_time_passed(ct, boot_time);
 	snprintf(Gbuf2,
 	         MAX_STRING_LENGTH,

--- a/src/actmove.c
+++ b/src/actmove.c
@@ -1369,7 +1369,7 @@ int do_simple_move_skipping_procs(P_char ch, int exitnumb, unsigned int flags)
 	    send_to_char
 	          ("The &+Radrenaline&n is pumping through you like mad, this sure is exhausting...&n\n", ch);
 
-	    if(IS_PC(ch) &&  IS_THIEF(ch) && ( ch->only.pc->pc_timer[1] + 3 > time(NULL) ) )
+	    if(IS_PC(ch) &&  IS_THIEF(ch) && ( ch->only.pc->pc_timer[1] + 3 > get_time() ) )
 	      send_to_char
 	                ("...but as the master of close combat, you take no notice!!&n\n", ch);
 	    else
@@ -1380,7 +1380,7 @@ int do_simple_move_skipping_procs(P_char ch, int exitnumb, unsigned int flags)
 	/* pc_timer[1] gets set on successful flee */
 	/*
 	 if( IS_PC(ch) &&
-	     (ch->only.pc->pc_timer[1] + (IS_THIEF(ch) ? 5 : 10) > time(NULL)))
+	     (ch->only.pc->pc_timer[1] + (IS_THIEF(ch) ? 5 : 10) > get_time()))
 	 {
 	   if( need_movement < 4)
 	     need_movement += 4;

--- a/src/actnew.c
+++ b/src/actnew.c
@@ -1990,10 +1990,10 @@ void shapechange_showShape(struct char_shapechange_data *curShape,
 
   strcat(buf, buf2);
 
-  if (curShape->lastShapechanged + TIME_BETWEEN_SHAPECHANGES > time(0))
+  if (curShape->lastShapechanged + TIME_BETWEEN_SHAPECHANGES > get_time())
   {
     snprintf(buf2, MAX_STRING_LENGTH, " (%d hours rest required)",
-        (curShape->lastShapechanged + TIME_BETWEEN_SHAPECHANGES - time(0))
+        (curShape->lastShapechanged + TIME_BETWEEN_SHAPECHANGES - get_time())
         / SECS_PER_MUD_HOUR);
     strcat(buf, buf2);
   }

--- a/src/actobj.c
+++ b/src/actobj.c
@@ -578,7 +578,7 @@ static void do_get_finalize_container_success(P_char ch, P_char hood, P_obj s_ob
 				{
 					int vnum      = OBJ_VNUM(o_obj);
 					int owner_pid = -1;
-					int timer     = time(NULL);
+					int timer     = get_time();
 					// This sets the 'soul' of the artifact to the new owner.
 					sql_update_bind_data(vnum, &owner_pid, &timer);
 					// Feed artifact to at least the minimum for across racewar sides.
@@ -3272,7 +3272,7 @@ void do_eat(P_char ch, char *argument, int cmd)
 		return;
 	}
 
-	if ((temp->value[1] < 0 || (temp->timer[0] && (time(NULL) - temp->timer[0] > 1 * 60 * 10))) && !IS_TRUSTED(ch))
+	if ((temp->value[1] < 0 || (temp->timer[0] && (get_time() - temp->timer[0] > 1 * 60 * 10))) && !IS_TRUSTED(ch))
 	{
 		act("That stinks, find some fresh food instead.", FALSE, ch, 0, 0, TO_CHAR);
 		return;

--- a/src/actoff.c
+++ b/src/actoff.c
@@ -2382,7 +2382,7 @@ void do_flee(P_char ch, char *argument, int cmd)
 	}
 
 	if (IS_PC(ch))
-		ch->only.pc->pc_timer[1] = time(NULL);
+		ch->only.pc->pc_timer[1] = get_time();
 
 	ch->points.delay_move = 0;
 

--- a/src/actoth.c
+++ b/src/actoth.c
@@ -282,7 +282,7 @@ void do_camp(P_char ch, char *arg, int cmd)
 			ch->desc->snoop.snooping = 0;
 		}
 
-		ct = time(NULL);
+		ct = get_time();
 		// Convert to EST.
 		ct -= 4 * 60 * 60;
 		snprintf(timestr, 1024, "%s", asctime(localtime(&ct)));
@@ -3598,7 +3598,7 @@ void do_bug(P_char ch, char *argument, int cmd)
 		return;
 	}
 
-	t = time(0);
+	t = get_time();
 
 	snprintf(buf, MAX_STRING_LENGTH, "%s **%s[%d]: %s\n", ctime(&t), GET_NAME(ch), world[ch->in_room].number, argument);
 
@@ -3650,7 +3650,7 @@ void do_cheat(P_char ch, char *argument, int cmd)
 		send_to_char("Could not open the cheat-file.\r\n", ch);
 		return;
 	}
-	t = time(0);
+	t = get_time();
 	snprintf(Gbuf1, MAX_STRING_LENGTH, "%s &+W%s[%d] reports following cheat:&+r %s&n\n", ctime(&t), GET_NAME(ch), world[ch->in_room].number, argument);
 	fputs(Gbuf1, fl);
 	fclose(fl);
@@ -6315,7 +6315,7 @@ void ascend_theurgist(P_char ch)
 	generate_desc(ch);
 
 	// GET_AGE does not return a changeable variable.
-	ch->player.time.birth = time(NULL) - 500 * SECS_PER_MUD_YEAR;
+	ch->player.time.birth = get_time() - 500 * SECS_PER_MUD_YEAR;
 
 	GET_VITALITY(ch) = GET_MAX_VITALITY(ch) = 120;
 	forget_spells(ch, -1);
@@ -6415,7 +6415,7 @@ void do_ascend(P_char ch, char *arg, int cmd)
 		GET_RACE(ch)               = RACE_AGATHINON;
 		generate_desc(ch);
 		// GET_AGE does not return a changeable variable.
-		ch->player.time.birth = time(NULL) - 500 * SECS_PER_MUD_YEAR;
+		ch->player.time.birth = get_time() - 500 * SECS_PER_MUD_YEAR;
 		ch->player.m_class    = CLASS_AVENGER;
 		do_start(ch, 1);
 		ch->only.pc->epics = MAX(0, ch->only.pc->epics - (int)get_property("ascend.epicCost", 250));
@@ -6879,7 +6879,7 @@ void do_old_descend(P_char ch, char *arg, int cmd)
 		send_to_char("You feel a chill and realize that you are naked.\r\n", ch);
 		generate_desc(ch);
 		// GET_AGE does not return a changeable variable.
-		ch->player.time.birth = time(NULL) - 1 * SECS_PER_MUD_YEAR;
+		ch->player.time.birth = get_time() - 1 * SECS_PER_MUD_YEAR;
 		GET_VITALITY(ch) = GET_MAX_VITALITY(ch) = 120;
 		forget_spells(ch, -1);
 		ch->player.spec            = 0;

--- a/src/actset.c
+++ b/src/actset.c
@@ -1473,7 +1473,7 @@ MAKE_COPY_FUNCTION(ubyte)
 static void ac_ageCopy(void *where, int offset, char *value, int bit, int on_off)
 {
 	long   secs;
-	time_t curr_time = time(NULL);
+	time_t curr_time = get_time();
 	P_char ch        = (P_char)where;
 
 	secs                  = (bit /* - 17 */) * SECS_PER_MUD_YEAR;
@@ -1613,7 +1613,7 @@ static void ac_hitmanaCopy(void *where, int offset, char *value, int bit, int on
 // Sets a time_t value.
 static void ac_timerCopy(void *where, int offset, char *value, int time_to_zero, int on_off)
 {
-	// So, we need to add the timer to time(NULL) to get the time when it should end.
+	// So, we need to add the timer to get_time() to get the time when it should end.
 	// And we need to adjust offset to handle the size difference between the time_t and char.
-	*((time_t *)(where) + (sizeof(char) * offset / sizeof(time_t))) = time(NULL) + time_to_zero;
+	*((time_t *)(where) + (sizeof(char) * offset / sizeof(time_t))) = get_time() + time_to_zero;
 }

--- a/src/actwiz.c
+++ b/src/actwiz.c
@@ -338,7 +338,7 @@ void sa_intCopy(P_char ch, unsigned long offset, int value) { bcopy((char *)&val
 void sa_ageCopy(P_char ch, unsigned long offset, int value)
 {
 	long   secs;
-	time_t curr_time = time(NULL);
+	time_t curr_time = get_time();
 
 	secs                  = (value - 17) * SECS_PER_MUD_YEAR;
 	ch->player.time.birth = curr_time - secs;
@@ -2182,7 +2182,7 @@ void do_stat(P_char ch, char *argument, int cmd)
 			}
 			if (IS_ARTIFACT(j))
 			{
-				long ct = time(0);
+				long ct = get_time();
 				strcat(buf, "&+YIn game since: &n");
 				strcat(buf, asctime(localtime(&(j->timer[5]))));
 				strcat(buf, "\n");
@@ -2387,20 +2387,20 @@ void do_stat(P_char ch, char *argument, int cmd)
 
 			playing_time =
 #ifndef EQ_WIPE
-				real_time_passed((long)(k->player.time.played + (time(0) - k->player.time.logon)), 0);
+				real_time_passed((long)(k->player.time.played + (get_time() - k->player.time.logon)), 0);
 #else
-				real_time_passed((long)(k->player.time.played - EQ_WIPE + (time(0) - k->player.time.logon)), 0);
+				real_time_passed((long)(k->player.time.played - EQ_WIPE + (get_time() - k->player.time.logon)), 0);
 #endif
 			snprintf(buf, MAX_STRING_LENGTH, "&+YPlayed:  &N%3d &+Ydays  &N%2d &+Yhours  &N%2d &+Yminutes\n", playing_time.day, playing_time.hour, playing_time.minute);
 			strcat(o_buf, buf);
 
-			playing_time = real_time_passed(time(0), k->player.time.logon);
+			playing_time = real_time_passed(get_time(), k->player.time.logon);
 			snprintf(buf, MAX_STRING_LENGTH, "&+YSession: &N%3d &+Ydays  &N%2d &+Yhours  &N%2d &+Yminutes\n", playing_time.day, playing_time.hour, playing_time.minute);
 			strcat(o_buf, buf);
 		}
 		else
 		{
-			playing_time = real_time_passed(time(0), k->player.time.birth);
+			playing_time = real_time_passed(get_time(), k->player.time.birth);
 			snprintf(buf, MAX_STRING_LENGTH, "&+YLived: &N%2d &+Ydays  &N%2d &+Yhours  &N%2d &+Yminutes\n", playing_time.day, playing_time.hour, playing_time.minute);
 			strcat(o_buf, buf);
 		}
@@ -2737,7 +2737,7 @@ void do_stat(P_char ch, char *argument, int cmd)
 			         k->only.pc->pc_timer[9]);
 			strcat(o_buf, buf);
 
-			now = time(NULL);
+			now = get_time();
 			snprintf(buf,
 			         MAX_STRING_LENGTH,
 			         "&+YTimers(left): T[STAT_POOL] = &N%8ld&+Y, T[FLEE]    = &N%8ld&+Y, T[HEAVEN] = &N%8ld&+Y,\n"
@@ -4120,7 +4120,7 @@ void timedShutdown(P_char ch, P_char, P_obj, void *data)
 		   }
 	   */
 		// how much longer until a reboot?
-		time_t secs = shutdownData.reboot_time - time(0);
+		time_t secs = shutdownData.reboot_time - get_time();
 		// special case:  going to reboot in less then ~1 second - force a restore all.
 		if ((secs <= 1) && (ch != NULL))
 		{
@@ -4200,7 +4200,7 @@ void displayShutdownMsg(P_char ch)
 		return;
 
 	char        buf[200];
-	time_t      secs = shutdownData.reboot_time - time(0);
+	time_t      secs = shutdownData.reboot_time - get_time();
 	const char *type = "REBOOT";
 	if (shutdownData.eShutdownType == TimedShutdownData::OK || shutdownData.eShutdownType == TimedShutdownData::PWIPE)
 	{
@@ -4375,7 +4375,7 @@ void do_shutdown(P_char ch, char *argument, int cmd)
 	strcpy(shutdownData.IssuedBy, GET_NAME(ch));
 	strlcpy(shutdownData.Reason, reason, sizeof shutdownData.Reason);
 	shutdownData.next_warning = -1;
-	shutdownData.reboot_time  = (time(0) + (mins_to_reboot * 60));
+	shutdownData.reboot_time  = (get_time() + (mins_to_reboot * 60));
 	snprintf(buf, sizeof buf, "Scheduled %s initiated by %s in %d minutes.", type, GET_NAME(ch), mins_to_reboot);
 	wizlog(60, buf);
 	sql_log(ch, WIZLOG, "%s initiated by %s in %d minutes.", type, GET_NAME(ch), mins_to_reboot);
@@ -4941,8 +4941,8 @@ void do_purge(P_char ch, char *argument, int cmd)
 
 				/* can't be too careful */
 
-				if ((time(0) - laston) >= 0)
-					timegone = (time(0) - laston) / 60;
+				if ((get_time() - laston) >= 0)
+					timegone = (get_time() - laston) / 60;
 				else
 					timegone = 0;
 
@@ -5328,7 +5328,7 @@ void do_start(P_char ch, int nomsg)
 #else
 	ch->player.time.played = EQ_WIPE;
 #endif
-	ch->player.time.logon = time(0);
+	ch->player.time.logon = get_time();
 }
 
 void do_advance(P_char ch, char *argument, int cmd)
@@ -7085,7 +7085,7 @@ void GetMIA(char *playerName, char *returned)
 	}
 
 	laston      = finger_foo->player.time.saved;
-	minutesgone = (time(0) - laston) / 60;
+	minutesgone = (get_time() - laston) / 60;
 
 	snprintf(returned, MAX_STRING_LENGTH, "  &n(&+cMIA: &+w");
 	if (minutesgone > 0)
@@ -7113,7 +7113,7 @@ void GetMIA(char *playerName, char *returned)
 	}
 	else
 	{
-		minutesgone = time(0) - laston;
+		minutesgone = get_time() - laston;
 		snprintf(returned + strlen(returned), MAX_STRING_LENGTH - strlen(returned), "%ld second%s", minutesgone, (minutesgone > 1) ? "s" : "");
 	}
 
@@ -7142,7 +7142,7 @@ void GetMIA2(char *playerName, char *returned)
 	}
 
 	laston   = finger_foo->player.time.saved;
-	timegone = time(0) - laston;
+	timegone = get_time() - laston;
 
 	days    = (timegone) / (3600 * 24);
 	hours   = (timegone % (3600 * 24)) / (3600);
@@ -7212,7 +7212,7 @@ void do_finger(P_char ch, char *arg, int cmd)
 	         get_class_string(finger_foo, Gbuf2),
 	         race_names_table[(int)GET_RACE(finger_foo)].ansi);
 	laston   = finger_foo->player.time.saved;
-	timegone = (time(0) - laston) / 60;
+	timegone = (get_time() - laston) / 60;
 	send_to_char(Gbuf1, ch);
 	pid = GET_PID(finger_foo);
 	snprintf(Gbuf1, MAX_STRING_LENGTH, "&+cPID:&n %d &+cLast saved:&n %s", pid, asctime(localtime(&laston)));
@@ -7267,7 +7267,7 @@ void do_finger(P_char ch, char *arg, int cmd)
 	{
 		/* Handled in GetMIA
 		if((lastConnect == 0) && (lastDisconnect == 0))
-		  timegone = (time(0) - laston);
+		  timegone = (get_time() - laston);
 		else
 		  timegone = lastDisconnect;
 		*/

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -497,7 +497,7 @@ void list_artifacts_sql(P_char ch, int type, bool Godlist, bool allArtis)
 		// calc TIME fresh from raw timestamp
 		cJSON *timerItem = cJSON_GetObjectItem(item, "timer");
 		long   timer     = timerItem ? (long)timerItem->valuedouble : 0;
-		long   totalTime = timer - time(NULL);
+		long   totalTime = timer - get_time();
 		bool   negTime   = FALSE;
 		if (totalTime < 0)
 		{
@@ -652,15 +652,15 @@ void artifact_feed_to_min_sql(P_obj arti, int min_minutes)
 	}
 
 	// Calculate the minimum time to poof in seconds.
-	to_time = time(NULL) + min_minutes * 60;
+	to_time = get_time() + min_minutes * 60;
 
 	// Arih : Validate to_time to prevent MySQL error "Incorrect datetime value: '1970-01-01 00:00:00'".
 	// When min_minutes is 0 or negative, FROM_UNIXTIME(0) causes MySQL to reject the datetime.
 	// Ensure to_time is never 0 or in the past (MySQL will reject FROM_UNIXTIME(0))
 	if (to_time <= 0)
 	{
-		to_time = time(NULL) + ARTIFACT_BLOOD_DAYS * SECS_PER_REAL_DAY; // 10 days, not 60 secs
-		logit(LOG_ARTIFACT, "artifact_feed_to_min_sql: WARNING: to_time was %ld, resetting to current time + 10 days for vnum %d", (long)(time(NULL) + min_minutes * 60), vnum);
+		to_time = get_time() + ARTIFACT_BLOOD_DAYS * SECS_PER_REAL_DAY; // 10 days, not 60 secs
+		logit(LOG_ARTIFACT, "artifact_feed_to_min_sql: WARNING: to_time was %ld, resetting to current time + 10 days for vnum %d", (long)(get_time() + min_minutes * 60), vnum);
 	}
 
 	if (!qry("select owned, UNIX_TIMESTAMP(timer) from artifacts where vnum = %d", vnum))
@@ -811,7 +811,7 @@ void artifact_switch_check(P_char ch, P_obj arti)
 	sql_get_bind_data(vnum, &owner_pid, &timer);
 
 	// If a pvp loot happened, and timeframe has passed, set to 0 for binding
-	if ((owner_pid == -1) && (timer + (60 * (int)get_property("artifact.feeding.switch.lootallowance.min", 30)) < time(NULL)))
+	if ((owner_pid == -1) && (timer + (60 * (int)get_property("artifact.feeding.switch.lootallowance.min", 30)) < get_time()))
 	{
 		owner_pid = 0;
 		update    = TRUE;
@@ -832,11 +832,11 @@ void artifact_switch_check(P_char ch, P_obj arti)
 		if (!timer)
 		{
 			logit(LOG_ARTIFACT, "artifact_switch_check: Timer on arti vnum %d was not set.", vnum);
-			timer  = time(NULL);
+			timer  = get_time();
 			update = TRUE;
 		}
 		// Otherwise if the timer is due, set it to the new player
-		else if ((timer + (60 * (int)get_property("artifact.feeding.switch.timer.min", 30))) < time(NULL))
+		else if ((timer + (60 * (int)get_property("artifact.feeding.switch.timer.min", 30))) < get_time())
 		{
 			act("&+L$p &+Lmerges with your &+wsoul&+L.", FALSE, ch, arti, 0, TO_CHAR);
 			owner_pid = GET_PID(ch);
@@ -1050,7 +1050,7 @@ void artifact_update_sql(P_obj arti, char owned, time_t timer)
 		// FROM_UNIXTIME(0) causes MySQL to reject the datetime.
 		if (timer <= 0)
 		{
-			timer = time(NULL) + ARTIFACT_BLOOD_DAYS * SECS_PER_REAL_DAY; // 10 days, not 60 secs
+			timer = get_time() + ARTIFACT_BLOOD_DAYS * SECS_PER_REAL_DAY; // 10 days, not 60 secs
 			logit(LOG_ARTIFACT, "arti_update_sql (UPDATE): WARNING: timer was %ld, resetting to 10 days for vnum %d", (long)0, vnum);
 		}
 
@@ -1072,7 +1072,7 @@ void artifact_update_sql(P_obj arti, char owned, time_t timer)
 		// FROM_UNIXTIME(0) causes MySQL to reject the datetime.
 		if (timer <= 0)
 		{
-			timer = time(NULL) + ARTIFACT_BLOOD_DAYS * SECS_PER_REAL_DAY; // 10 days, not 60 secs
+			timer = get_time() + ARTIFACT_BLOOD_DAYS * SECS_PER_REAL_DAY; // 10 days, not 60 secs
 			logit(LOG_ARTIFACT, "arti_update_sql: WARNING: timer was %ld, resetting to 10 days for vnum %d", (long)0, vnum);
 		}
 
@@ -1120,7 +1120,7 @@ void artifact_update_sql(int vnum, bool owned, int locType, int location, time_t
 	// FROM_UNIXTIME(0) causes MySQL to reject the datetime.
 	if (timer <= 0)
 	{
-		timer = time(NULL) + ARTIFACT_BLOOD_DAYS * SECS_PER_REAL_DAY; // 10 days, not 60 secs
+		timer = get_time() + ARTIFACT_BLOOD_DAYS * SECS_PER_REAL_DAY; // 10 days, not 60 secs
 		logit(LOG_ARTIFACT, "artifact_update_sql: WARNING: timer was %ld, resetting to 10 days for vnum %d", (long)0, vnum);
 	}
 
@@ -1274,7 +1274,7 @@ void artifact_update_location_sql(P_obj arti)
 			if (!timerStarted)
 			{
 				// Set the timer to the max for a newly acquired arti.
-				artidata.timer = time(NULL) + ARTIFACT_BLOOD_DAYS * SECS_PER_REAL_DAY;
+				artidata.timer = get_time() + ARTIFACT_BLOOD_DAYS * SECS_PER_REAL_DAY;
 			}
 			// PC owner forces a start to timer.
 			artifact_update_sql(arti, 'Y', artidata.timer);
@@ -1367,13 +1367,13 @@ void artifact_feed_sql(P_char owner, P_obj arti, int feed_seconds, bool soulChec
 	}
 
 	// Get data from DB.
-	poof_time = time(NULL) + ARTIFACT_BLOOD_DAYS * SECS_PER_REAL_DAY;
+	poof_time = get_time() + ARTIFACT_BLOOD_DAYS * SECS_PER_REAL_DAY;
 
 	// Arih : Validate poof_time to prevent MySQL error "Incorrect datetime value: '1970-01-01 00:00:00'".
 	// FROM_UNIXTIME(0) causes MySQL to reject the datetime.
 	if (poof_time <= 0)
 	{
-		poof_time = time(NULL) + ARTIFACT_BLOOD_DAYS * SECS_PER_REAL_DAY; // 10 days, not 60 secs
+		poof_time = get_time() + ARTIFACT_BLOOD_DAYS * SECS_PER_REAL_DAY; // 10 days, not 60 secs
 		logit(LOG_ARTIFACT, "artifact_feed_sql: WARNING: poof_time was %ld, resetting to 10 days for vnum %d", (long)0, vnum);
 	}
 
@@ -1612,7 +1612,7 @@ void artifact_timer_sql(int vnum, char *buffer)
 	{
 		if (artidata.owned)
 		{
-			timer = artidata.timer - time(NULL);
+			timer = artidata.timer - get_time();
 		}
 		else
 		{
@@ -2682,7 +2682,7 @@ void arti_hunt_sql(P_char ch, char *arg)
 					extract_obj(arti2);
 				}
 				// If they managed to get it on pfile and not in DB, give them full timer.
-				artifact_update_sql(arti, 'Y', time(NULL) + ARTIFACT_BLOOD_DAYS * SECS_PER_REAL_DAY);
+				artifact_update_sql(arti, 'Y', get_time() + ARTIFACT_BLOOD_DAYS * SECS_PER_REAL_DAY);
 			}
 			else if (artidata.locType == ARTIFACT_ON_PC || artidata.locType == ARTIFACT_ONCORPSE)
 			{
@@ -2743,7 +2743,7 @@ void arti_hunt_sql(P_char ch, char *arg)
 				{
 					send_to_char("&+WNot yet tracked - adding.&n\n", ch);
 					// If they managed to get it on pfile and not in DB, give them full timer.
-					artifact_update_sql(arti, 'Y', time(NULL) + ARTIFACT_BLOOD_DAYS * SECS_PER_REAL_DAY);
+					artifact_update_sql(arti, 'Y', get_time() + ARTIFACT_BLOOD_DAYS * SECS_PER_REAL_DAY);
 					// If there's one in zone, pull it.
 					if ((arti2 = artifact_find(OBJ_VNUM(arti))))
 					{
@@ -3057,7 +3057,7 @@ void arti_timer_sql(P_char ch, char *arg)
 	}
 	else if (cmd == COMMAND_SET)
 	{
-		new_time = time(NULL) + 60 * minutes;
+		new_time = get_time() + 60 * minutes;
 	}
 	else
 	{
@@ -3066,16 +3066,16 @@ void arti_timer_sql(P_char ch, char *arg)
 	}
 
 	// Minimum of 1 minute.
-	if (new_time < time(NULL))
+	if (new_time < get_time())
 	{
 		send_to_char("&+WNew time is less than &+w0&+W minutes, setting to &+w1&+W minute.&n\n\r", ch);
-		new_time = time(NULL) + 60;
+		new_time = get_time() + 60;
 	}
 	// And max.
-	if (new_time > time(NULL) + ARTIFACT_BLOOD_DAYS * SECS_PER_REAL_DAY)
+	if (new_time > get_time() + ARTIFACT_BLOOD_DAYS * SECS_PER_REAL_DAY)
 	{
 		send_to_char("&+WOops, went a little over max, didn't ya?&n\n\r", ch);
-		new_time = time(NULL) + ARTIFACT_BLOOD_DAYS * SECS_PER_REAL_DAY;
+		new_time = get_time() + ARTIFACT_BLOOD_DAYS * SECS_PER_REAL_DAY;
 	}
 
 	snprintf(buf, MAX_STRING_LENGTH, "&+WArtifact '&+w%s&+W' &+w%d&+W has had it's timer changed from &n", artishort, vnum);
@@ -3376,7 +3376,7 @@ void event_artifact_check_bind_sql(P_char ch, P_char vict, P_obj obj, void *arg)
 	}
 
 	timer_length = 60 * get_property("artifact.feeding.switch.lootallowance.min", 15);
-	curr_time    = time(NULL);
+	curr_time    = get_time();
 
 	bindData = list = NULL;
 	while ((row = mysql_fetch_row(res)))
@@ -3523,8 +3523,8 @@ void arti_fixit_sql(P_char ch)
 	}
 	mysql_free_result(res);
 
-	new_time  = time(NULL) + ARTIFACT_BLOOD_DAYS * SECS_PER_REAL_DAY;
-	curr_time = (int)time(NULL);
+	new_time  = get_time() + ARTIFACT_BLOOD_DAYS * SECS_PER_REAL_DAY;
+	curr_time = (int)get_time();
 
 	counter = 0;
 	// Walk through each arti that's on a PC.
@@ -3882,7 +3882,7 @@ void arti_player_sql(P_char ch, char *arg)
 		{
 			totalTime = 0;
 		}
-		if ((totalTime = atol(row[4]) - time(NULL)) < 0)
+		if ((totalTime = atol(row[4]) - get_time()) < 0)
 		{
 			negTime = TRUE;
 			totalTime *= -1;

--- a/src/assocs.c
+++ b/src/assocs.c
@@ -735,7 +735,7 @@ void Guild::kick(P_char ch)
 	frag_remove(ch);
 	GET_ASSOC(ch) = NULL;
 	GET_NB_LEFT_GUILD(ch) += 1;
-	GET_TIME_LEFT_GUILD(ch) = time(NULL);
+	GET_TIME_LEFT_GUILD(ch) = get_time();
 	SET_NO_THANKS(GET_A_BITS(ch));
 	clear_title(ch);
 
@@ -1659,7 +1659,7 @@ void do_society(P_char member, char *argument, int cmd)
 		}
 		temp_time += SECS_PER_REAL_DAY * get_property("guild.secede.delay.days", 2);
 
-		if (time(NULL) >= temp_time)
+		if (get_time() >= temp_time)
 		{
 			send_to_char("Look like you can join another guild!\n", member);
 			SET_NO_THANKS(GET_A_BITS(member));
@@ -2578,7 +2578,7 @@ void Guild::secede(P_char member)
 
 	GET_ASSOC(member) = NULL;
 	GET_NB_LEFT_GUILD(member) += 1;
-	GET_TIME_LEFT_GUILD(member) = time(NULL);
+	GET_TIME_LEFT_GUILD(member) = get_time();
 	SET_NO_THANKS(GET_A_BITS(member));
 	clear_title(member);
 

--- a/src/auction_houses.c
+++ b/src/auction_houses.c
@@ -834,7 +834,7 @@ bool auction_offer(P_char ch, char *args)
 
 	// Preserve the id before the character save issues further SQL.
 	int new_auction_id = mysql_insert_id(DB);
-	int end_time       = time(NULL) + auction_length;
+	int end_time       = get_time() + auction_length;
 	string offered_short = tmp_obj->short_description;
 
 	// Detach, but do not destroy, the items until the inventory removal and

--- a/src/boards.c
+++ b/src/boards.c
@@ -254,7 +254,7 @@ void Board_write_message(int board_type, struct char_data *ch, char *arg)
 		return;
 	}
 
-	ct                           = time(0);
+	ct                           = get_time();
 	tmstr                        = (char *)asctime(localtime(&ct));
 	*(tmstr + strlen(tmstr) - 9) = '\0'; /* kill seconds and year */
 

--- a/src/boon.c
+++ b/src/boon.c
@@ -2127,7 +2127,7 @@ int boon_display(P_char ch, char *argument)
 
 		if (duration != -1)
 		{
-			ct    = time(0);
+			ct    = get_time();
 			timer = real_time_countdown(ct, timethen, duration * 60);
 			snprintf(cdtime, MAX_STRING_LENGTH, "%2d:%02d:%02d", timer.day * 24 + timer.hour, timer.minute, timer.second);
 		}
@@ -2397,7 +2397,7 @@ int create_boon(BoonData *bdata)
 
 	if (qry("INSERT INTO boons (time, duration, racewar, type, opt, criteria, criteria2, bonus, bonus2, random, author, active, pid, rpt) VALUES "
 	        "(%d, %d, %d, %d, %d, %f, %f, %f, %f, %d, '%s', 1, '%d', '%d')",
-	        time(0),
+	        get_time(),
 	        bdata->duration,
 	        bdata->racewar,
 	        bdata->type,
@@ -2511,8 +2511,8 @@ int extend_boon(int id, int extend, const char *name)
 		return FALSE;
 	}
 
-	int calculate = MAX(0, timethen + (duration * 60) - time(0));
-	int ct        = calculate + time(0);
+	int calculate = MAX(0, timethen + (duration * 60) - get_time());
+	int ct        = calculate + get_time();
 	duration      = extend;
 
 	if (!qry("UPDATE boons SET time = '%d', duration = '%d', active = '1', author = '*%s' WHERE id = '%d'", ct, duration, name, id))
@@ -2707,7 +2707,7 @@ void boon_maintenance()
 
 		// check durations and expire if necessesary
 		expire = FALSE;
-		if ((bdata.duration != -1) && (bdata.time + (bdata.duration * 60)) < time(0))
+		if ((bdata.duration != -1) && (bdata.time + (bdata.duration * 60)) < get_time())
 		{
 			boon_notify(bdata.id, NULL, BN_EXPIRE);
 			remove_boon(bdata.id);

--- a/src/comm.c
+++ b/src/comm.c
@@ -214,7 +214,7 @@ int main(int argc, char **argv)
 	randomize(0);
 	for (;;)
 	{
-		int this_option_optind = optind ? optind : 1;
+		uint64_t seed;
 		int option_index = 0;
 		static struct option long_options[] = {
 			{"material-rarity-report", 2, 0, -2 },
@@ -227,10 +227,11 @@ int main(int argc, char **argv)
 			{"mini",                   0, 0, 'm'},
 			{"area-debug",             0, 0, 'z'},
 			{"copyover",               0, 0, 'C'},
+			{"random-seed",            1, 0, 'R'},
 			{0}
 		};
 
-		int c = getopt_long(argc, argv, "fld:spmz",
+		int c = getopt_long(argc, argv, "fld:spmzCR:",
                              long_options, &option_index);
 		if (c == -1)
 			break;
@@ -283,6 +284,13 @@ int main(int argc, char **argv)
 			// copyover boot - sockets recovered from copyover.dat
 			copyover_boot = 1;
 			logit(LOG_STATUS, "Copyover boot mode");
+			break;
+		case 'R':
+			seed = 0;
+			for (; *optarg; optarg++)
+				seed = hash64(seed) ^ *optarg;
+			randomize(seed);
+			logit(LOG_STATUS, "Seeded random mode.");
 			break;
 		default:
 			fatal_boot_error("comm", "Usage: %s [-l] [-m] [-s] [-p] [-f] [-d pathname] [ port # ]", argv[0]);

--- a/src/comm.c
+++ b/src/comm.c
@@ -17,6 +17,7 @@
 #include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <getopt.h>
 #include <gnutls/gnutls.h>
 #include <arpa/inet.h>
 #include <netdb.h>
@@ -203,7 +204,6 @@ size_t output_length;
 int main(int argc, char **argv)
 {
 	int         port, sslport;
-	int         pos = 1;
 	const char *dir;
 	int         migrate_mode = 0;
 
@@ -212,100 +212,102 @@ int main(int argc, char **argv)
 	sslport = SSL_PORT;
 
 	randomize(0);
-
-	// check for --migrate-all before regular arg parsing
-	for (int i = 1; i < argc; i++)
+	for (;;)
 	{
-		if (!strncmp(argv[i], "--material-rarity-report", strlen("--material-rarity-report")))
+		int this_option_optind = optind ? optind : 1;
+		int option_index = 0;
+		static struct option long_options[] = {
+			{"material-rarity-report", 2, 0, -2 },
+			{"migrate-all",            0, 0, -3 },
+			{"no-ferries",             0, 0, 'f'},
+			{"no-randoms",             0, 0, 'l'},
+			{"dir",                    1, 0, 'd'},
+			{"no-specials",            0, 0, 's'},
+			{"passwd",                 0, 0, 'p'},
+			{"mini",                   0, 0, 'm'},
+			{"area-debug",             0, 0, 'z'},
+			{"copyover",               0, 0, 'C'},
+			{0}
+		};
+
+		int c = getopt_long(argc, argv, "fld:spmz",
+                             long_options, &option_index);
+		if (c == -1)
+			break;
+
+		switch (c)
 		{
-			const char *value = argv[i] + strlen("--material-rarity-report");
-			if (*value == '=')
-				value++;
-			else if (!*value && i + 1 < argc)
-				value = argv[++i];
-			material_rarity_report_dir = *value ? value : "material-rarity-report";
+		case -2:
+			if (optarg && *optarg)
+				material_rarity_report_dir = optarg;
+			else
+				material_rarity_report_dir = "material-rarity-report";
 			material_rarity_report_mode = TRUE;
 			break;
-		}
-		if (!strcmp(argv[i], "--migrate-all"))
-		{
+		case -3:
 			migrate_mode = 1;
 			break;
-		}
-	}
+		case 'f':
+			no_ferries = 1;
+			logit(LOG_STATUS, "Without ferries.");
+			break;
+		case 'l':
+			no_random = 1;
+			// lawful = 1;
+			logit(LOG_STATUS, "Without randoms.");
+			break;
+		case 'd':
+			if (!optarg || !*optarg)
+				fatal_boot_error("comm", "Directory arg expected after option -d.");
 
-	while ((pos < argc) && (*(argv[pos]) == '-'))
-	{
-		if (!strncmp(argv[pos], "--material-rarity-report", strlen("--material-rarity-report")))
-		{
-			if (argv[pos][strlen("--material-rarity-report")] == '\0' && pos + 1 < argc)
-				pos++;
-			pos++;
-			continue;
-		}
-		switch (*(argv[pos] + 1))
-		{
-			case 'f':
-				no_ferries = 1;
-				logit(LOG_STATUS, "Without ferries.");
-				break;
-			case 'l':
-				no_random = 1;
-				// lawful = 1;
-				logit(LOG_STATUS, "Without randoms.");
-				break;
-			case 'd':
-				if (*(argv[pos] + 2))
-					dir = argv[pos] + 2;
-				else if (++pos < argc)
-					dir = argv[pos];
-				else
-				{
-					fatal_boot_error("comm", "Directory arg expected after option -d.");
-				}
-				break;
-			case 's':
-				no_specials = 1;
-				logit(LOG_STATUS, "Suppressing assignment of special routines.");
-				break;
-			case 'p':
-				req_passwd = 0;
-				logit(LOG_STATUS, "Allowing changing of password without old one.");
-				break;
-			case 'm':
-				mini_mode  = 1;
-				no_ferries = 1;
-				logit(LOG_STATUS, "Running in mini mode");
-				break;
-			case 'z':
-				mini_mode = 2;
-				logit(LOG_STATUS, "Running with area debugger on");
-				break;
-			case 'C':
-				// copyover boot - sockets recovered from copyover.dat
-				copyover_boot = 1;
-				logit(LOG_STATUS, "Copyover boot mode");
-				break;
-			default:
-				logit(LOG_STATUS, "Unknown option -% in argument string.", *(argv[pos] + 1));
-				break;
-		}
-		pos++;
-	}
-
-	if (pos < argc)
-	{
-		if (!isdigit(*argv[pos]))
-		{
+			dir = optarg;
+			break;
+		case 's':
+			no_specials = 1;
+			logit(LOG_STATUS, "Suppressing assignment of special routines.");
+			break;
+		case 'p':
+			req_passwd = 0;
+			logit(LOG_STATUS, "Allowing changing of password without old one.");
+			break;
+		case 'm':
+			mini_mode  = 1;
+			no_ferries = 1;
+			logit(LOG_STATUS, "Running in mini mode");
+			break;
+		case 'z':
+			mini_mode = 2;
+			logit(LOG_STATUS, "Running with area debugger on");
+			break;
+		case 'C':
+			// copyover boot - sockets recovered from copyover.dat
+			copyover_boot = 1;
+			logit(LOG_STATUS, "Copyover boot mode");
+			break;
+		default:
 			fatal_boot_error("comm", "Usage: %s [-l] [-m] [-s] [-p] [-f] [-d pathname] [ port # ]", argv[0]);
 		}
-		else if ((port = atoi(argv[pos])) <= 1024)
-		{
-			fatal_boot_error("comm", "Illegal port #");
-		}
-		else
-			sslport = port + 1;
 	}
+
+	if (optind < argc)
+	{
+		if (!isdigit(*argv[optind]))
+			fatal_boot_error("comm", "Port number expected, got '%s'", argv[optind]);
+		if ((port = atoi(argv[optind])) <= 1024 || port > 65535)
+			fatal_boot_error("comm", "Illegal port #");
+		sslport = port + 1;
+		optind++;
+	}
+
+	if (optind < argc)
+	{
+		if (!isdigit(*argv[optind]))
+			fatal_boot_error("comm", "Port number expected, got '%s'", argv[optind]);
+		if ((sslport = atoi(argv[optind])) <= 1024 || sslport > 65535)
+			fatal_boot_error("comm", "Illegal port #");
+		optind++;
+	}
+
 	// Global variable so can check if mainmud or not!
 	RUNNING_PORT = port;
 

--- a/src/comm.c
+++ b/src/comm.c
@@ -110,7 +110,7 @@ bool game_booted  = FALSE;
 
 void request_shutdown(int shutdown_type, const char *issuer, const char *reason)
 {
-	shutdownData.reboot_time  = time(0);
+	shutdownData.reboot_time  = get_time();
 	shutdownData.next_warning = -1;
 	snprintf(shutdownData.IssuedBy, sizeof(shutdownData.IssuedBy), "%s", issuer ? issuer : "Launcher");
 	snprintf(shutdownData.Reason, sizeof(shutdownData.Reason), "%s", reason ? reason : "signal from launcher");
@@ -176,6 +176,8 @@ struct mm_ds         *dead_desc_pool = NULL;
 int                   RUNNING_PORT   = 0;
 int                   no_random      = 0;
 int                   no_ferries     = 0;
+int                   fast           = 0;
+time_t                vtime, vtime0;
 
 // copyover support
 int        copyover_boot             = 0;
@@ -228,10 +230,11 @@ int main(int argc, char **argv)
 			{"area-debug",             0, 0, 'z'},
 			{"copyover",               0, 0, 'C'},
 			{"random-seed",            1, 0, 'R'},
+			{"fast",                   0, 0, 'F'},
 			{0}
 		};
 
-		int c = getopt_long(argc, argv, "fld:spmzCR:",
+		int c = getopt_long(argc, argv, "fld:spmzCR:F",
                              long_options, &option_index);
 		if (c == -1)
 			break;
@@ -291,6 +294,10 @@ int main(int argc, char **argv)
 				seed = hash64(seed) ^ *optarg;
 			randomize(seed);
 			logit(LOG_STATUS, "Seeded random mode.");
+			break;
+		case 'F':
+			fast = 1;
+			logit(LOG_STATUS, "No delay mode.  Gotta go fast!");
 			break;
 		default:
 			fatal_boot_error("comm", "Usage: %s [-l] [-m] [-s] [-p] [-f] [-d pathname] [ port # ]", argv[0]);
@@ -369,11 +376,19 @@ int main(int argc, char **argv)
 
 	load_event_names();
 
+	vtime0 = vtime = time(0);
 	init_cmdlog(); /* init cmd.debug file - DCL */
 
 	run_the_game(port, sslport);
 
 	return (0);
+}
+
+time_t get_time(void)
+{
+	if (fast)
+		return vtime;
+	return time(0);
 }
 
 // all text meant to go to executing_ch - a player whos command
@@ -829,7 +844,7 @@ void game_loop(int port, int sslport)
 	copyover_boot   = 0;
 	copyover_clear_boot();
 
-	long    last_desc_per_hour_reset = time(0);
+	long    last_desc_per_hour_reset = get_time();
 	clock_t loop_time_end;
 	/* Main loop */
 	while (!shutdownflag)
@@ -846,10 +861,10 @@ void game_loop(int port, int sslport)
 		//PROFILE_END(process_signal_shutdown_pending);
 		checkpointing();
 
-		if ((last_desc_per_hour_reset + 3600) <= time(0))
+		if ((last_desc_per_hour_reset + 3600) <= get_time())
 		{
 			max_descs_this_hour = used_descs;
-			last_desc_per_hour_reset = time(0);
+			last_desc_per_hour_reset = get_time();
 		}
 		/*
 		    struct host_answer host_ans_buf;
@@ -1355,6 +1370,8 @@ void game_loop(int port, int sslport)
 			debug("Huge value for tics, resetting to 1.");
 			logit(LOG_SYS, "Huge value for tics, resetting to 1.");
 		}
+		if (!(pulse & 3))
+			vtime++;
 		pulse++;
 		after_events_call = FALSE;
 		clock_t affect_and_points_begin = clock();
@@ -1388,7 +1405,7 @@ void game_loop(int port, int sslport)
 		suseconds_t usec_spent = (suseconds_t)(loop_time * 1000 * 1000);
 		timeout.tv_usec = MAX(0, timeout.tv_usec - usec_spent);
 
-		if (timeout.tv_sec || timeout.tv_usec)
+		if ((timeout.tv_sec || timeout.tv_usec) && !fast)
 		{
 
 			/*

--- a/src/copyover.c
+++ b/src/copyover.c
@@ -503,7 +503,7 @@ void copyover_save(int mother_desc, int mother_desc_ssl, int ws_desc)
 	memset(&header, 0, sizeof(header));
 	memcpy(header.magic, COPYOVER_MAGIC, 4);
 	header.version         = COPYOVER_VERSION;
-	header.timestamp       = time(NULL);
+	header.timestamp       = get_time();
 	header.num_descriptors = num_descs;
 	header.num_mobs        = num_mobs;
 	header.num_objects     = num_objs;

--- a/src/ctf.c
+++ b/src/ctf.c
@@ -160,10 +160,10 @@ int ctf_flag_proc(P_obj flag, P_char ch, int cmd, char *argument)
 	if (cmd == CMD_PERIODIC && OBJ_ROOM(flag) && !OBJ_IN_ROOM(ctfdata[i].obj, real_room0(ctfdata[i].room)))
 	{
 		if (!flag->timer[0])
-			flag->timer[0] = time(NULL);
+			flag->timer[0] = get_time();
 		else
 		{
-			if ((flag->timer[0] + (reset * 60)) <= time(NULL))
+			if ((flag->timer[0] + (reset * 60)) <= get_time())
 			{
 				// Not needed because reload makes us a new flag
 				flag->timer[0] = 0; // But just in case...

--- a/src/db.c
+++ b/src/db.c
@@ -407,7 +407,7 @@ void boot_db(int mini_mode)
 {
 	logit(LOG_STATUS, "Boot db -- BEGIN.");
 	fprintf(stderr, "\nBoot db -- BEGIN.\r\n");
-	boot_time = time(0);
+	boot_time = get_time();
 
 	logit(LOG_STATUS, "Resetting the game time:");
 	fprintf(stderr, "Resetting the game time:\r\n");
@@ -734,7 +734,7 @@ void reset_time(void)
 {
 	long beginning_of_time = 650336715;
 
-	time_info = mud_time_passed(time(0), beginning_of_time);
+	time_info = mud_time_passed(get_time(), beginning_of_time);
 
 	logit(LOG_STATUS,
 	      "   Current Gametime:  %d/%d/%d  %d%s",
@@ -2315,9 +2315,9 @@ P_char read_mobile(int nr, int type)
 
 	if (letter == 'S')
 	{
-		mob->player.time.birth  = time(0);
+		mob->player.time.birth  = get_time();
 		mob->player.time.played = 0;
-		mob->player.time.logon  = time(0);
+		mob->player.time.logon  = get_time();
 
 		for (i = 0; i < 3; i++)
 			GET_COND(mob, i) = -1;
@@ -2448,9 +2448,9 @@ P_char read_mobile(int nr, int type)
 #endif
 
 		fscanf(mob_f, " %ld ", &tmp);
-		mob->player.time.birth  = time(0);
+		mob->player.time.birth  = get_time();
 		mob->player.time.played = 0;
-		mob->player.time.logon  = time(0);
+		mob->player.time.logon  = get_time();
 
 		fscanf(mob_f, " %ld ", &tmp); /* weight */
 
@@ -2915,7 +2915,7 @@ P_obj read_object(int nr, int type)
 	  add_event(event_artifact_poof, 2 * WAIT_SEC, 0, 0, obj, 0, 0, 0);
 	  // Set current timer?  Not necessary as event_artifact_poof will fix it?
 	  //   Not really sure atm.. will test this and see what happens...
-	  obj->timer[3] = time(NULL);
+	  obj->timer[3] = get_time();
 	}
 	*/
 
@@ -3084,7 +3084,7 @@ void reset_zone(int zone, int force_item_repop)
 						}
 						obj_to_obj(obj, obj_to);
 						// Artifact poof timer to BLOOD_DAYS * secs in a day.
-						obj->timer[3] = time(NULL);
+						obj->timer[3] = get_time();
 						last_cmd      = 1;
 						break;
 					}
@@ -3143,7 +3143,7 @@ void reset_zone(int zone, int force_item_repop)
 
 					obj_to_room(obj, ZCMD.arg3);
 					// Artifact poof timer to BLOOD_DAYS * secs in a day.
-					obj->timer[3] = time(NULL);
+					obj->timer[3] = get_time();
 					last_cmd      = 1;
 
 					break;

--- a/src/debug.c
+++ b/src/debug.c
@@ -95,7 +95,7 @@ void cmdlog(P_char ch, char *str)
 		{
 			rewind(cmdfile);
 		}
-		ct = time(0);
+		ct = get_time();
 		strcpy(tbuf, asctime(localtime(&ct)));
 		tbuf[strlen(tbuf) - 1] = '\0';
 		fprintf(cmdfile, "%s :: [%d] %s in %d: %s\n", tbuf, logcount, GET_NAME(ch), world[ch->in_room].number, str);

--- a/src/epic.c
+++ b/src/epic.c
@@ -1030,7 +1030,7 @@ int epic_stone(P_obj obj, P_char ch, int cmd, char *arg)
 				update_epic_zone_alignment(zone_number, delta);
 
 			// set completed flag
-			epic_zone_completions.push_back(epic_zone_completion(zone_number, time(NULL), delta));
+			epic_zone_completions.push_back(epic_zone_completion(zone_number, get_time(), delta));
 			redis_invalidate_epic_zones();
 			db_query("UPDATE zones SET last_touch = NOW() WHERE number = '%d'", zone_number);
 			db_query("INSERT INTO zone_touches (boot_time, touched_at, zone_number, toucher_pid, group_size, epic_value, alignment_delta) VALUES (FROM_UNIXTIME(%d), NOW(), %d, %d, %d, %d, %d);",
@@ -1085,7 +1085,7 @@ void epic_zone_balance()
 
 		// debug("zone %d alignment %d", epic_zones[i].number, alignment);
 
-		if ((time(NULL) - lt) > ((int)get_property("epic.alignment.reset.hour", 7 * 24) * 60 * 60))
+		if ((get_time() - lt) > ((int)get_property("epic.alignment.reset.hour", 7 * 24) * 60 * 60))
 		{
 			if (alignment > 0)
 				delta = -1;
@@ -1515,7 +1515,7 @@ bool epic_zone_done(int zone_number)
 {
 	for (vector<epic_zone_completion>::iterator it = epic_zone_completions.begin(); it != epic_zone_completions.end(); it++)
 	{
-		if ((it->number == zone_number) && (time(NULL) - it->done_at) > (int)get_property("epic.showCompleted.delaySecs", (15 * 60)))
+		if ((it->number == zone_number) && (get_time() - it->done_at) > (int)get_property("epic.showCompleted.delaySecs", (15 * 60)))
 		{
 			return TRUE;
 		}
@@ -1529,7 +1529,7 @@ int epic_zone_data::displayed_alignment() const
 
 	for (vector<epic_zone_completion>::iterator it = epic_zone_completions.begin(); it != epic_zone_completions.end(); it++)
 	{
-		if ((it->number == this->number) && (time(NULL) - it->done_at) < (int)get_property("epic.showCompleted.delaySecs", (15 * 60)))
+		if ((it->number == this->number) && (get_time() - it->done_at) < (int)get_property("epic.showCompleted.delaySecs", (15 * 60)))
 		{
 			return this->alignment - it->delta;
 		}

--- a/src/fight.c
+++ b/src/fight.c
@@ -833,7 +833,7 @@ void setHeavenTime(P_char victim)
 			time_in_heaven *= 24;
 	}
 
-	victim->only.pc->pc_timer[PC_TIMER_HEAVEN] = time(NULL) + time_in_heaven;
+	victim->only.pc->pc_timer[PC_TIMER_HEAVEN] = get_time() + time_in_heaven;
 	debug("%s time in heaven: until %s = %d seconds, recent deaths = %d.", J_NAME(victim),
 	      asctime(localtime(&(victim->only.pc->pc_timer[PC_TIMER_HEAVEN]))), time_in_heaven,
 	      counter);
@@ -9084,7 +9084,7 @@ void perform_violence(void)
 	bool			melee_exp_pulse;
 	// loop through everyone fighting
 
-	time_now	= time(0);
+	time_now	= get_time();
 	melee_exp_pulse = ((pulse % PULSE_VIOLENCE) == 0);
 
 	for (ch = destroying_list; ch; ch = ch->specials.next_destroying)

--- a/src/files.c
+++ b/src/files.c
@@ -333,7 +333,7 @@ int writeStatus(char *buf, P_char ch, bool updateTime)
 	ADD_LONG(buf, ch->player.time.birth);
 	if (updateTime)
 	{
-		tmpl = time(0);
+		tmpl = get_time();
 		tmp  = ch->player.time.played + (int)(tmpl - ch->player.time.logon);
 		ADD_INT(buf, tmp);   /* player age in secs */
 		ADD_LONG(buf, tmpl); /* last save time */
@@ -1209,7 +1209,7 @@ void writeCorpse(P_obj corpse)
 	}
 
 	if (corpse->value[CORPSE_SAVEID] == 0)
-		corpse->value[CORPSE_SAVEID] = time(NULL);
+		corpse->value[CORPSE_SAVEID] = get_time();
 
 	if (!sql_save_corpse(corpse))
 	{
@@ -1322,7 +1322,7 @@ static int persistence_write_character_flat_fallback(P_char ch, int type, int ro
 	ADD_INT(buf, (int)0);
 	ADD_INT(buf, (ch->specials.act3));
 	ADD_INT(buf, room);
-	ADD_LONG(buf, time(0));
+	ADD_LONG(buf, get_time());
 
 	buf += writeStatus(buf, ch, ((type != RENT_POOFARTI) && (type != RENT_SWAPARTI) && (type != RENT_FIGHTARTI)) ? TRUE : FALSE);
 	ADD_INT(skill_off, (int)(buf - fallback_buff));
@@ -1933,7 +1933,7 @@ int restoreStatus(char *buf, P_char ch)
 	ch->player.time.birth      = GET_LONG(buf);
 	ch->player.time.played     = GET_INTE(buf);
 	ch->player.time.saved      = GET_LONG(buf); /* last save time */
-	ch->player.time.logon      = time(0);       /* set it */
+	ch->player.time.logon      = get_time();       /* set it */
 	GET_SHORT(buf); //!!! oerm_aging
 	for (i = 0; i < MAX_CIRCLE + 1; i++)
 		ch->specials.undead_spell_slots[i] = GET_BYTE(buf);
@@ -2120,7 +2120,7 @@ int restoreStatus(char *buf, P_char ch)
 			GET_A_BITS(ch) = 0;
 			GET_INTE(buf);
 			// Set time left guild to now
-			GET_TIME_LEFT_GUILD(ch) = time(0);
+			GET_TIME_LEFT_GUILD(ch) = get_time();
 			GET_LONG(buf);
 			// Increment number of times left guild.
 			GET_NB_LEFT_GUILD(ch) = GET_BYTE(buf) + 1;
@@ -3966,7 +3966,7 @@ int writePet(P_char ch)
 	ADD_INT(buf, (int)0);
 	ADD_INT(buf, mob_index[GET_RNUM(ch)].virtual_number);
 
-	ADD_LONG(buf, time(0)); /* save time */
+	ADD_LONG(buf, get_time()); /* save time */
 
 	/* unequip everything and remove affects before saving */
 
@@ -4164,7 +4164,7 @@ int restorePetStatus(char *buf, P_char ch)
 	mob_index[GET_RNUM(ch)].virtual_number = GET_INTE(buf);
 	GET_BIRTHPLACE(ch)                     = GET_INTE(buf);
 
-	ch->player.time.birth = time(0);
+	ch->player.time.birth = get_time();
 	ch->base_stats.Str    = (ubyte)GET_BYTE(buf);
 	ch->base_stats.Dex    = (ubyte)GET_BYTE(buf);
 	ch->base_stats.Agi    = (ubyte)GET_BYTE(buf);

--- a/src/fraglist.c
+++ b/src/fraglist.c
@@ -510,7 +510,7 @@ void do_fraglist(P_char ch, char *arg, int cmd)
 	// get level cap info (already uses sql)
 	get_level_cap_info(&cap_frags, &cap_racewar, &cap_level, &cap_timer);
 	cap_others = sql_level_cap((cap_racewar == RACEWAR_GOOD) ? RACEWAR_EVIL : RACEWAR_GOOD);
-	cap_timer -= time(NULL);
+	cap_timer -= get_time();
 
 	if (cap_timer <= 0)
 	{

--- a/src/gmcp.c
+++ b/src/gmcp.c
@@ -51,7 +51,7 @@ static int verify_durisweb_sig(const char *sig)
 	if (!secret)
 		return 0;
 
-	time_t now    = time(NULL);
+	time_t now    = time(0);
 	long   minute = now / 60;
 
 	for (int offset = 0; offset <= 1; offset++)

--- a/src/handler.c
+++ b/src/handler.c
@@ -3472,10 +3472,10 @@ void extract_char(P_char ch)
 				switch (GET_RACEWAR(ch))
 				{
 					case RACEWAR_GOOD:
-						ch->desc->account->acct_good = time(NULL);
+						ch->desc->account->acct_good = get_time();
 						break;
 					case RACEWAR_EVIL:
-						ch->desc->account->acct_evil = time(NULL);
+						ch->desc->account->acct_evil = get_time();
 						break;
 				}
 			}

--- a/src/justice.c
+++ b/src/justice.c
@@ -439,7 +439,7 @@ void justice_action_invader(P_char ch)
 	}
 	else
 	{
-		zone_struct->last_raid = time(0);
+		zone_struct->last_raid = get_time();
 	}
 
 	if (IS_INVADER(ch))

--- a/src/justice.h
+++ b/src/justice.h
@@ -132,7 +132,7 @@ extern const char          *town_name_list[];
 // removed check for dracos, it is performed very ineffectively, and why should alarm sound on just lesser dracos anyways? -Odorf
 #define NPC_INVADER(a, b) (IS_NPC(a) && !TRUSTED_NPC(a) && (!BORNHERE(a, b) || IS_MORPH(a)) && (IS_SET(hometowns[b - 1].flags, EVILRACE(a) ? JUSTICE_GOODHOME : GOODRACE(a) ? JUSTICE_EVILHOME : 0)))
 
-#define IS_TOWN_RAIDED(ch) (zone_table[world[ch->in_room].zone].last_raid + 200 > time(0))
+#define IS_TOWN_RAIDED(ch) (zone_table[world[ch->in_room].zone].last_raid + 200 > get_time())
 
 /* need a special ma for dealing with elf-town and invaders */
 

--- a/src/limits.c
+++ b/src/limits.c
@@ -1511,7 +1511,7 @@ void point_update(void)
 
 	*Gbuf1 = '\0';
 	// Subtract 5 hrs: GMT -> EST.
-	ct = time(0) - 5 * 60 * 60;
+	ct = get_time() - 5 * 60 * 60;
 	snprintf(timestr, MAX_STRING_LENGTH, "%s", asctime(localtime(&ct)));
 	*(timestr + strlen(timestr) - 1) = '\0';
 	strcat(timestr, " EST");

--- a/src/locker_async.c
+++ b/src/locker_async.c
@@ -817,7 +817,7 @@ int locker_async_mark_dirty(P_char chLocker, P_char chUser, int terminal, const 
 	{
 		s->state = LCHK_DIRTY;
 		s->gen = g_gen_seq++;
-		s->dirty_at = time(NULL);
+		s->dirty_at = get_time();
 	}
 
 	logit(LOG_DEBUG,
@@ -946,7 +946,7 @@ static void apply_result(struct locker_async_result *r)
 		s->rebuild_objects = 0;
 		s->state = LCHK_DIRTY;
 		s->gen = g_gen_seq++;
-		s->dirty_at = time(NULL);
+		s->dirty_at = get_time();
 		if (chLocker)
 			s->chLocker = chLocker;
 		if (chUser)
@@ -961,7 +961,7 @@ static void apply_result(struct locker_async_result *r)
 		/* Keep terminal-not-durable slot as DIRTY/busy fence. */
 		s->state = LCHK_DIRTY;
 		s->gen = g_gen_seq++;
-		s->dirty_at = time(NULL);
+		s->dirty_at = get_time();
 	}
 }
 

--- a/src/magic.c
+++ b/src/magic.c
@@ -5766,7 +5766,7 @@ void spell_ray_of_enfeeblement(int level, P_char ch, char *arg, int type, P_char
 void AgeChar(P_char ch, int years)
 {
 	long   played, secs;
-	time_t curr_time = time(NULL);
+	time_t curr_time = get_time();
 
 	if (IS_NPC(ch))
 		return;
@@ -8624,7 +8624,7 @@ void spell_channel(int level, P_char ch, P_char victim, P_obj obj)
 				af.flags     = AFFTYPE_NODISPEL;
 				affect_join(vict, &af, FALSE, FALSE);
 				SET_POS(vict, POS_PRONE + GET_STAT(vict));
-				vict->only.pc->pc_timer[3] = time(NULL);
+				vict->only.pc->pc_timer[3] = get_time();
 				if (ch != vict && avatar->desc)
 				{
 					vict->desc->snoop.snooping = avatar;
@@ -19806,7 +19806,7 @@ void set_up_portals(P_char ch, P_obj p1, P_obj p2, int charge)
 	int temp;
 
 	// set when portal is created, for initial stabilization
-	p1->timer[0] = time(0);
+	p1->timer[0] = get_time();
 	if (p2)
 		p2->timer[0] = p1->timer[0];
 	//----------------------------

--- a/src/mail.c
+++ b/src/mail.c
@@ -348,7 +348,7 @@ void store_mail(char *to, char *from, char *message_pointer)
 	strlcpy(header.to, to, sizeof header.to);
 	/*  tmp = str_dup(header.to);
 	 *tmp = LOWER(*tmp);*/
-	header.mail_time                  = time(0);
+	header.mail_time                  = get_time();
 	header.txt[HEADER_BLOCK_DATASIZE] = header.from[NAME_SIZE] = header.to[NAME_SIZE] = '\0';
 
 	target_address = pop_free_list(); /* find next free block */
@@ -621,7 +621,7 @@ void do_mail(P_char ch, char *arg, int cmd)
 		return;
 	}
 
-	int curr_time = time(NULL);
+	int curr_time = get_time();
 
 	P_obj furnace, new_obj;
 	if (curr_time < (1135362289 + 60 * 60 * 24 * 2))

--- a/src/mining.c
+++ b/src/mining.c
@@ -245,7 +245,7 @@ P_obj get_ore_from_mine(P_char ch, int mine_quality)
 	{
 		return NULL;
 	}
-	ore->value[4] = time(NULL);
+	ore->value[4] = get_time();
 	return ore;
 }
 
@@ -253,7 +253,7 @@ P_obj get_gem_from_mine(P_char ch, int mine_quality)
 {
 	P_obj gem = read_object(mining_config_gem_vnum(), VIRTUAL);
 	if (!gem) return NULL;
-	gem->value[4] = time(NULL);
+	gem->value[4] = get_time();
 	return gem;
 }
 

--- a/src/nanny.c
+++ b/src/nanny.c
@@ -1697,7 +1697,7 @@ void perform_eq_wipe(P_char ch)
 	if (longestptime < ch->player.time.played)
 	{
 		longestptime = ch->player.time.played;
-		playing_time = real_time_passed((long)((time(0) - ch->player.time.logon) + ch->player.time.played), 0);
+		playing_time = real_time_passed((long)((get_time() - ch->player.time.logon) + ch->player.time.played), 0);
 		snprintf(Gbuf1,
 		         MAX_STRING_LENGTH,
 		         "New Longest Ptime: '%s' %d with %d %dD%dH%dM%dS",
@@ -1792,7 +1792,7 @@ void enter_game(P_desc d)
 	int                  cost;
 	int                  r_room    = NOWHERE;
 	long                 time_gone = 0, hit_g, move_g, heal_time, rest;
-	time_t               ct        = time(NULL);
+	time_t               ct        = get_time();
 	int                  mana_g;
 	char                 Gbuf1[MAX_STRING_LENGTH], timestr[MAX_STRING_LENGTH];
 	bool                 nobonus = FALSE;
@@ -4688,9 +4688,9 @@ void init_char(P_char ch)
 	ch->player.short_descr       = 0;
 	ch->player.long_descr        = 0;
 	ch->player.description       = 0;
-	ch->player.time.birth        = time(0);
+	ch->player.time.birth        = get_time();
 	ch->player.time.played       = 0;
-	ch->player.time.logon        = time(0);
+	ch->player.time.logon        = get_time();
 	ch->only.pc->prestige        = 0; /* clear this early, so we can use as newby timer */
 	ch->only.pc->nb_left_guild   = 0;
 	ch->only.pc->time_left_guild = 0;
@@ -5001,7 +5001,7 @@ void nanny(P_desc d, char *arg)
 			if (*arg == 'y' || *arg == 'Y')
 			{
 				SEND_TO_Q("\r\nEntering new character generation mode.\r\n", d);
-				d->character->only.pc->pc_timer[PC_TIMER_HEAVEN] = time(NULL);
+				d->character->only.pc->pc_timer[PC_TIMER_HEAVEN] = get_time();
 				SEND_TO_Q(namechart, d);
 				STATE(d) = CON_APPROPRIATE_NAME;
 			}
@@ -5262,7 +5262,7 @@ void nanny(P_desc d, char *arg)
 				SEND_TO_Q(
 					"Now you have to wait for your character to be approved by a god.\r\nProcess should not take long.\r\nIf no god is on to approve you, you will &+WNOT&N be auto-approved.\r\n", d);
 				STATE(d)                                         = CON_ACCEPTWAIT;
-				d->character->only.pc->pc_timer[PC_TIMER_HEAVEN] = time(NULL) - d->character->only.pc->pc_timer[PC_TIMER_HEAVEN];
+				d->character->only.pc->pc_timer[PC_TIMER_HEAVEN] = get_time() - d->character->only.pc->pc_timer[PC_TIMER_HEAVEN];
 				newby_announce(d);
 			}
 			else

--- a/src/necromancy.c
+++ b/src/necromancy.c
@@ -1101,7 +1101,7 @@ void create_saved_corpse(P_obj obj, P_char mob)
 	clone_container_obj(savecorpse, obj);
 	snprintf(buff, MAX_STRING_LENGTH, "%s %s", savecorpse->name, "_savecorpse_");
 	savecorpse->name                 = str_dup(buff);
-	savecorpse->value[CORPSE_SAVEID] = time(NULL);
+	savecorpse->value[CORPSE_SAVEID] = get_time();
 	obj_to_room(savecorpse, real_room(40));
 	affect_from_obj(savecorpse, TAG_OBJ_DECAY);
 	SavedCorpseData savedCorpseData;

--- a/src/new_events.c
+++ b/src/new_events.c
@@ -1245,7 +1245,7 @@ void show_world_events(P_char ch, const char *arg)
 #ifdef DO_PROFILE
 
 PROFILES(DEFINE);
-bool do_profile = TRUE;
+bool do_profile = false;;
 
 void save_profile_data(const char *name, double total_inside, double total_outside, unsigned total)
 {

--- a/src/new_events.c
+++ b/src/new_events.c
@@ -1078,7 +1078,7 @@ void check_nevents()
 		}
 	}
 	if (shown)
-		debug("%ld is current time.", time(NULL));
+		debug("%ld is current time.", get_time());
 }
 
 void event_broken(struct char_link_data *cld)

--- a/src/nexus_stones.c
+++ b/src/nexus_stones.c
@@ -397,7 +397,7 @@ bool nexus_stone_touch(P_obj stone, P_char ch)
 		will_turn = true;
 	}
 
-	int time_now = time(NULL);
+	int time_now = get_time();
 
 	if (!IS_TRUSTED(ch) && will_turn && STONE_TURN_TIMER(stone) > (time_now - get_property("nexusStones.turnTimerSecs", 10)))
 	{
@@ -530,7 +530,7 @@ int nexus_stone(P_obj stone, P_char ch, int cmd, char *arg)
 		// find nexus sage; if not there, spawn one
 		P_char sage = get_nexus_sage(STONE_ID(stone));
 
-		int time_now = time(NULL);
+		int time_now = get_time();
 
 		if (!sage && STONE_TURNED(stone) && (STONE_SAGE_TIMER(stone) < (time_now - (int)get_property("nexusStones.sage.respawnWaitSecs", 3600))))
 		{
@@ -1081,7 +1081,7 @@ int nexus_sage_train(P_char ch, P_char pl, char *arg)
 	P_obj ns = get_nexus_stone(stone_id);
 
 	if (ns)
-		STONE_SAGE_TIMER(ns) = time(NULL);
+		STONE_SAGE_TIMER(ns) = get_time();
 
 	return TRUE;
 }
@@ -1127,7 +1127,7 @@ int nexus_sage(P_char ch, P_char pl, int cmd, char *arg)
 			return TRUE;
 		}
 
-		STONE_SAGE_TIMER(ns) = time(NULL);
+		STONE_SAGE_TIMER(ns) = get_time();
 
 		if (ch->specials.alignment > 0)
 		{
@@ -1299,19 +1299,19 @@ bool load_nexus_stone(int stone_id, const char *stone_name, int room_vnum, int a
 
 	if (align <= STONE_ALIGN_EVIL)
 	{
-		STONE_TURN_TIMER(stone) = time(NULL);
+		STONE_TURN_TIMER(stone) = get_time();
 		load_guardian(stone_id, real_room(room_vnum), STONE_ALIGN_EVIL);
 		// load_sage(stone_id, real_room(room_vnum), STONE_ALIGN_EVIL);
 	}
 	else if (align >= STONE_ALIGN_GOOD)
 	{
-		STONE_TURN_TIMER(stone) = time(NULL);
+		STONE_TURN_TIMER(stone) = get_time();
 		load_guardian(stone_id, real_room(room_vnum), STONE_ALIGN_GOOD);
 		// load_sage(stone_id, real_room(room_vnum), STONE_ALIGN_GOOD);
 	}
 	else if (align == 0)
 	{
-		STONE_TURN_TIMER(stone) = time(NULL);
+		STONE_TURN_TIMER(stone) = get_time();
 		load_guardian(stone_id, real_room(room_vnum), 0);
 	}
 

--- a/src/nq.c
+++ b/src/nq.c
@@ -515,7 +515,7 @@ int nq_find_actor(P_char mob, struct nq_quest **quest, struct nq_instance **inst
 			if ((*actor)->ch == mob)
 				return 1;
 		for (*instance = (*quest)->instance; *instance; *instance = (*instance)->next)
-			if ((*instance)->expires < time(0))
+			if ((*instance)->expires < get_time())
 				for (*actor = (*instance)->actor; *actor; *actor = (*actor)->next)
 					if ((*actor)->ch == mob)
 						return 1;
@@ -773,7 +773,7 @@ struct nq_instance *nq_accept_quest(struct nq_quest *quest, P_char ch)
 	CREATE(instance, nq_instance, 1, MEM_TAG_NQINST);
 	memset(instance, 0, sizeof(struct nq_instance));
 	instance->questor = str_dup(ch->player.name);
-	instance->expires = time(0) + quest->duration_minutes * 60;
+	instance->expires = get_time() + quest->duration_minutes * 60;
 
 	for (i = 1; quest->actor_template[i]; i++)
 	{

--- a/src/outposts.c
+++ b/src/outposts.c
@@ -1460,7 +1460,7 @@ void event_outposts_upkeep(P_char ch, P_char vict, P_obj obj, void *data)
 					if (building->get_guild() == guild)
 					{
 						// give them an hour after boot to get things in order before dropping
-						if (real_time_passed(time(0), boot_time).hour < 1 && real_time_passed(time(0), boot_time).day < 1)
+						if (real_time_passed(get_time(), boot_time).hour < 1 && real_time_passed(get_time(), boot_time).day < 1)
 						{
 							continue;
 						}

--- a/src/persistence_queue.c
+++ b/src/persistence_queue.c
@@ -22,6 +22,7 @@
  * translation unit. */
 extern void wizlog(int level, const char *format, ...);
 extern void logit(const char *filename, const char *format, ...);
+extern time_t get_time(void);
 
 #define PERSISTENCE_WORKER_STOP_JOIN_TIMEOUT_SECS 2
 
@@ -395,14 +396,14 @@ static void *persistence_item_event_worker_main(void *unused)
      * MySQL call, or anywhere else without releasing the mutex will
      * leave this stale and be flagged as stuck by
      * persistence_item_event_worker_stuck() on the main thread. */
-    persistence_item_event_worker_last_heartbeat = time(NULL);
+    persistence_item_event_worker_last_heartbeat = get_time();
     while (persistence_item_event_queue.count <= 0 &&
            !persistence_item_event_worker_stop_requested)
     {
       pthread_cond_wait(&persistence_item_event_queue_cond,
                         &persistence_item_event_queue_mutex);
       /* Refresh heartbeat after waking from cond_wait too. */
-      persistence_item_event_worker_last_heartbeat = time(NULL);
+      persistence_item_event_worker_last_heartbeat = get_time();
     }
 
     if (persistence_item_event_worker_stop_requested &&
@@ -488,7 +489,7 @@ int persistence_item_event_worker_start(persistence_item_event_writer writer,
   persistence_item_event_worker_stop_requested = 0;
   persistence_item_event_worker_drain_requested = 0;
   persistence_item_event_worker_is_running = 1;
-  persistence_item_event_worker_last_heartbeat = time(NULL);
+  persistence_item_event_worker_last_heartbeat = get_time();
   pthread_mutex_unlock(&persistence_item_event_queue_mutex);
 
   result = pthread_create(&persistence_item_event_worker_thread, NULL,
@@ -514,7 +515,7 @@ void persistence_item_event_worker_stop(int drain_remaining)
                 persistence_item_event_worker_stop_pending_flag;
   stuck = was_running &&
           persistence_item_event_worker_last_heartbeat != 0 &&
-          (int)(time(NULL) - persistence_item_event_worker_last_heartbeat) >=
+          (int)(get_time() - persistence_item_event_worker_last_heartbeat) >=
             PERSISTENCE_WORKER_HEARTBEAT_STUCK_SECS;
   persistence_item_event_worker_stop_pending_flag = was_running ? 1 : persistence_item_event_worker_stop_pending_flag;
   if (stuck)
@@ -585,7 +586,7 @@ int persistence_item_event_worker_running(void)
       else
       {
         last = persistence_item_event_worker_last_heartbeat;
-        age = last ? (int)(time(NULL) - last) : -1;
+        age = last ? (int)(get_time() - last) : -1;
         if (age >= PERSISTENCE_WORKER_HEARTBEAT_STUCK_SECS)
         {
           /* Heartbeat staleness is not proof that the pthread exited.  Keep
@@ -921,13 +922,13 @@ static void *persistence_scalar_event_worker_main(void *unused)
 
     pthread_mutex_lock(&persistence_scalar_event_queue_mutex);
     /* Deadlock-detection heartbeat: see item worker. */
-    persistence_scalar_event_worker_last_heartbeat = time(NULL);
+    persistence_scalar_event_worker_last_heartbeat = get_time();
     while (persistence_scalar_event_queue.count <= 0 &&
            !persistence_scalar_event_worker_stop_requested)
     {
       pthread_cond_wait(&persistence_scalar_event_queue_cond,
                         &persistence_scalar_event_queue_mutex);
-      persistence_scalar_event_worker_last_heartbeat = time(NULL);
+      persistence_scalar_event_worker_last_heartbeat = get_time();
     }
 
     if (persistence_scalar_event_worker_stop_requested &&
@@ -1013,7 +1014,7 @@ int persistence_scalar_event_worker_start(persistence_scalar_event_writer writer
   persistence_scalar_event_worker_stop_requested = 0;
   persistence_scalar_event_worker_drain_requested = 0;
   persistence_scalar_event_worker_is_running = 1;
-  persistence_scalar_event_worker_last_heartbeat = time(NULL);
+  persistence_scalar_event_worker_last_heartbeat = get_time();
   pthread_mutex_unlock(&persistence_scalar_event_queue_mutex);
 
   result = pthread_create(&persistence_scalar_event_worker_thread, NULL,
@@ -1039,7 +1040,7 @@ void persistence_scalar_event_worker_stop(int drain_remaining)
                 persistence_scalar_event_worker_stop_pending_flag;
   stuck = was_running &&
           persistence_scalar_event_worker_last_heartbeat != 0 &&
-          (int)(time(NULL) - persistence_scalar_event_worker_last_heartbeat) >=
+          (int)(get_time() - persistence_scalar_event_worker_last_heartbeat) >=
             PERSISTENCE_WORKER_HEARTBEAT_STUCK_SECS;
   persistence_scalar_event_worker_stop_pending_flag = was_running ? 1 : persistence_scalar_event_worker_stop_pending_flag;
   if (stuck)
@@ -1108,7 +1109,7 @@ int persistence_scalar_event_worker_running(void)
       else
       {
         last = persistence_scalar_event_worker_last_heartbeat;
-        age = last ? (int)(time(NULL) - last) : -1;
+        age = last ? (int)(get_time() - last) : -1;
         if (age >= PERSISTENCE_WORKER_HEARTBEAT_STUCK_SECS)
         {
           persistence_scalar_event_worker_stop_pending_flag = 1;
@@ -1169,13 +1170,13 @@ static void *persistence_large_event_worker_main(void *unused)
 
     pthread_mutex_lock(&persistence_large_event_queue_mutex);
     /* Deadlock-detection heartbeat: see item worker. */
-    persistence_large_event_worker_last_heartbeat = time(NULL);
+    persistence_large_event_worker_last_heartbeat = get_time();
     while (persistence_large_event_queue.count <= 0 &&
            !persistence_large_event_worker_stop_requested)
     {
       pthread_cond_wait(&persistence_large_event_queue_cond,
                         &persistence_large_event_queue_mutex);
-      persistence_large_event_worker_last_heartbeat = time(NULL);
+      persistence_large_event_worker_last_heartbeat = get_time();
     }
 
     if (persistence_large_event_worker_stop_requested &&
@@ -1261,7 +1262,7 @@ int persistence_large_event_worker_start(persistence_scalar_event_writer writer,
   persistence_large_event_worker_stop_requested = 0;
   persistence_large_event_worker_drain_requested = 0;
   persistence_large_event_worker_is_running = 1;
-  persistence_large_event_worker_last_heartbeat = time(NULL);
+  persistence_large_event_worker_last_heartbeat = get_time();
   pthread_mutex_unlock(&persistence_large_event_queue_mutex);
 
   result = pthread_create(&persistence_large_event_worker_thread, NULL,
@@ -1287,7 +1288,7 @@ void persistence_large_event_worker_stop(int drain_remaining)
                 persistence_large_event_worker_stop_pending_flag;
   stuck = was_running &&
           persistence_large_event_worker_last_heartbeat != 0 &&
-          (int)(time(NULL) - persistence_large_event_worker_last_heartbeat) >=
+          (int)(get_time() - persistence_large_event_worker_last_heartbeat) >=
             PERSISTENCE_WORKER_HEARTBEAT_STUCK_SECS;
   persistence_large_event_worker_stop_pending_flag = was_running ? 1 : persistence_large_event_worker_stop_pending_flag;
   if (stuck)
@@ -1356,7 +1357,7 @@ int persistence_large_event_worker_running(void)
       else
       {
         last = persistence_large_event_worker_last_heartbeat;
-        age = last ? (int)(time(NULL) - last) : -1;
+        age = last ? (int)(get_time() - last) : -1;
         if (age >= PERSISTENCE_WORKER_HEARTBEAT_STUCK_SECS)
         {
           persistence_large_event_worker_stop_pending_flag = 1;
@@ -1407,7 +1408,7 @@ int persistence_item_event_worker_heartbeat_age(void)
   if (last == 0)
     return -1;
 
-  age = (int)(time(NULL) - last);
+  age = (int)(get_time() - last);
   return age >= 0 ? age : 0;
 }
 
@@ -1433,7 +1434,7 @@ int persistence_item_event_worker_stuck(int threshold_secs)
   if (last == 0)
     return 0;
 
-  age = (int)(time(NULL) - last);
+  age = (int)(get_time() - last);
   if (age < 0)
     age = 0;
   return age >= threshold_secs;
@@ -1462,7 +1463,7 @@ int persistence_scalar_event_worker_heartbeat_age(void)
   if (last == 0)
     return -1;
 
-  age = (int)(time(NULL) - last);
+  age = (int)(get_time() - last);
   return age >= 0 ? age : 0;
 }
 
@@ -1488,7 +1489,7 @@ int persistence_scalar_event_worker_stuck(int threshold_secs)
   if (last == 0)
     return 0;
 
-  age = (int)(time(NULL) - last);
+  age = (int)(get_time() - last);
   if (age < 0)
     age = 0;
   return age >= threshold_secs;
@@ -1517,7 +1518,7 @@ int persistence_large_event_worker_heartbeat_age(void)
   if (last == 0)
     return -1;
 
-  age = (int)(time(NULL) - last);
+  age = (int)(get_time() - last);
   return age >= 0 ? age : 0;
 }
 
@@ -1543,7 +1544,7 @@ int persistence_large_event_worker_stuck(int threshold_secs)
   if (last == 0)
     return 0;
 
-  age = (int)(time(NULL) - last);
+  age = (int)(get_time() - last);
   if (age < 0)
     age = 0;
   return age >= threshold_secs;

--- a/src/persistence_queue.h
+++ b/src/persistence_queue.h
@@ -82,7 +82,7 @@ int persistence_large_event_worker_heartbeat_age(void);
 
 /* Test helpers – set the heartbeat timestamp to simulate a stale worker.
  * These can be used by tests to avoid waiting for the real timeout.
- * Pass time(NULL) - age_secs to set the heartbeat to `age_secs` seconds ago. */
+ * Pass get_time() - age_secs to set the heartbeat to `age_secs` seconds ago. */
 void persistence_item_event_worker_heartbeat_set(time_t timestamp);
 void persistence_scalar_event_worker_heartbeat_set(time_t timestamp);
 void persistence_large_event_worker_heartbeat_set(time_t timestamp);

--- a/src/poll.c
+++ b/src/poll.c
@@ -186,7 +186,7 @@ static void poll_send_option_results(P_char ch, int opt_num, const char *text, c
 /* format time remaining */
 static void format_time_remaining(time_t expires_at, char *buf, size_t buflen)
 {
-	time_t remaining = expires_at - time(NULL);
+	time_t remaining = expires_at - get_time();
 
 	if (remaining <= 0)
 	{
@@ -244,7 +244,7 @@ vector<poll_data> poll_get_all(bool active_only)
 	{
 		res = db_query("SELECT id, question, created_by, UNIX_TIMESTAMP(created_at), UNIX_TIMESTAMP(expires_at), is_active, multi_select, max_choices "
 		               "FROM polls WHERE is_active = 1 AND expires_at > FROM_UNIXTIME(%ld) ORDER BY id DESC",
-		               (long)time(NULL));
+		               (long)get_time());
 	}
 	else
 	{
@@ -477,7 +477,7 @@ int poll_cast_vote(P_char ch, int poll_id, vector<int> &choices)
 void poll_check_expirations(void)
 {
 #ifndef __NO_MYSQL__
-	qry("UPDATE polls SET is_active = 0 WHERE is_active = 1 AND expires_at < FROM_UNIXTIME(%ld)", (long)time(NULL));
+	qry("UPDATE polls SET is_active = 0 WHERE is_active = 1 AND expires_at < FROM_UNIXTIME(%ld)", (long)get_time());
 #endif
 }
 
@@ -510,7 +510,7 @@ int poll_record_votes(const char *acct_name, const char *char_name, int poll_id,
 		        poll_id,
 		        acct_esc.c_str(),
 		        option_id,
-		        (long)time(NULL),
+		        (long)get_time(),
 		        char_esc.c_str()))
 		{
 			votes_cast++;
@@ -904,7 +904,7 @@ static void poll_wizard_show_summary(P_char ch, poll_wizard_data *wiz)
 		send_to_char("\r\n", ch);
 	}
 
-	time_t duration = wiz->poll.expires_at - time(NULL);
+	time_t duration = wiz->poll.expires_at - get_time();
 	snprintf(buf, MAX_STRING_LENGTH, "&+YDuration:&n %ld hours\r\n", (long)(duration / 3600));
 	send_to_char(buf, ch);
 
@@ -989,8 +989,8 @@ void poll_wizard_handle_input(P_char ch, char *input)
 				send_to_char("Please enter hours between 1 and 720 (30 days max):\r\n", ch);
 				return;
 			}
-			wiz.poll.created_at = time(NULL);
-			wiz.poll.expires_at = time(NULL) + (atoi(arg) * 3600);
+			wiz.poll.created_at = get_time();
+			wiz.poll.expires_at = get_time() + (atoi(arg) * 3600);
 			wiz.state           = POLL_WIZ_OPTIONS;
 			wiz.current_option  = 1;
 			send_to_char("\r\n&+YEnter option 1 (or 'done' when finished adding options):&n\r\n", ch);

--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -762,6 +762,7 @@ void        close_sockets(int);
 int         is_desc_valid(P_desc);
 void        flush_queues(P_desc);
 void        nonblock(int);
+time_t      get_time();
 void        parse_name(P_desc, char *);
 void        perform_complex(P_char, P_char, P_obj, P_obj, char *, int, int);
 void        perform_to_all(const char *, P_char);

--- a/src/random.zone.c
+++ b/src/random.zone.c
@@ -880,7 +880,7 @@ int relic_proc(P_obj obj, P_char ch, int cmd, char *arg)
 		if (obj->value[6] == 0 && IS_PC(ch))
 		{
 			obj->value[6] = 1;
-			obj->timer[3] = time(NULL) - (90 * 60 * 60);
+			obj->timer[3] = get_time() - (90 * 60 * 60);
 			update_relic(ch, obj);
 
 			for (d = descriptor_list; d; d = d->next)
@@ -1490,7 +1490,7 @@ int create_lab(int type)
 						}
 						else
 						{
-							obj->timer[3] = time(NULL) - (85 * 60 * 60);
+							obj->timer[3] = get_time() - (85 * 60 * 60);
 							obj_to_char(obj, mob);
 							relic_in_game = 1;
 						}

--- a/src/randomeq.c
+++ b/src/randomeq.c
@@ -1573,7 +1573,7 @@ int random_eq_proc(P_obj obj, P_char ch, int cmd, char *argument)
 		return FALSE;
 	}
 
-	curr_time = time(NULL);
+	curr_time = get_time();
 	// obj->value[6] = GET_VNUM(mob);
 	// obj->value[7] = named_spells[1];
 

--- a/src/redis.c
+++ b/src/redis.c
@@ -428,7 +428,7 @@ void redis_log_floor_drop(P_obj obj, int room_vnum)
 	if (OBJ_VNUM(obj) == 2 && obj->value[6] > 0)
 	{
 		time_t corpse_time = (time_t)obj->value[6];
-		if (time(NULL) - corpse_time > 86400)
+		if (get_time() - corpse_time > 86400)
 			return;
 	}
 
@@ -790,7 +790,7 @@ static int dirty_debounce_count = 0;
 // returns true if we should proceed, false if debounced
 static bool check_dirty_debounce(int pid)
 {
-	time_t now = time(NULL);
+	time_t now = get_time();
 
 	for (int i = 0; i < dirty_debounce_count; i++)
 	{
@@ -1127,7 +1127,7 @@ static bool redis_save_world_state_json(redisContext *ctx)
 		return false;
 
 	cJSON_AddNumberToObject(root, "ver", REDIS_WORLD_STATE_VER);
-	cJSON_AddNumberToObject(root, "ts", (double)time(NULL));
+	cJSON_AddNumberToObject(root, "ts", (double)get_time());
 
 	// mobs array
 	cJSON *mobs = cJSON_CreateArray();
@@ -1265,7 +1265,7 @@ static bool redis_save_world_state_json(redisContext *ctx)
 		if (vnum == 2 && obj->value[6] > 0)
 		{
 			time_t corpse_time = (time_t)obj->value[6];
-			if (time(NULL) - corpse_time > 86400)
+			if (get_time() - corpse_time > 86400)
 				continue;
 		}
 
@@ -1376,7 +1376,7 @@ static bool redis_save_world_state_json(redisContext *ctx)
 	freeReplyObject(reply);
 
 	char timestamp_str[32];
-	snprintf(timestamp_str, sizeof(timestamp_str), "%ld", (long)time(NULL));
+	snprintf(timestamp_str, sizeof(timestamp_str), "%ld", (long)get_time());
 	reply = (redisReply *)redisCommand(ctx, "SET mud:world_state:timestamp %s", timestamp_str);
 	if (reply)
 		freeReplyObject(reply);
@@ -1519,7 +1519,7 @@ bool redis_has_world_state(void)
 	if (saved_time == 0)
 		return false;
 
-	time_t now = time(NULL);
+	time_t now = get_time();
 	if (now - saved_time > world_state_max_age)
 	{
 		logit(LOG_SYS, "redis: world state too old (%ld seconds), ignoring", (long)(now - saved_time));
@@ -2829,7 +2829,7 @@ static char *generate_fraglist_output(void)
 
 	get_level_cap_info(&cap_frags, &cap_racewar, &cap_level, &cap_timer);
 	cap_others = sql_level_cap((cap_racewar == RACEWAR_GOOD) ? RACEWAR_EVIL : RACEWAR_GOOD);
-	cap_timer -= time(NULL);
+	cap_timer -= get_time();
 
 	if (cap_timer <= 0)
 	{

--- a/src/specializations.c
+++ b/src/specializations.c
@@ -626,7 +626,7 @@ void do_specialize(P_char ch, char *argument, int cmd)
 	while (*argument == ' ')
 		argument++;
 
-	if (time(NULL) < ch->only.pc->time_unspecced)
+	if (get_time() < ch->only.pc->time_unspecced)
 	{
 		snprintf(buf, MAX_STRING_LENGTH, "You cannot specialize until %s.\r\n", asctime(localtime(&ch->only.pc->time_unspecced)));
 		send_to_char(buf, ch);

--- a/src/specs.eth2.c
+++ b/src/specs.eth2.c
@@ -306,7 +306,7 @@ int eth2_godsfury(P_obj obj, P_char ch, int cmd, char *arg)
 			return FALSE;
 		}
 
-		int curr_time = time(NULL);
+		int curr_time = get_time();
 
 		if (!CHAR_IN_NO_MAGIC_ROOM(ch))
 		{
@@ -388,7 +388,7 @@ int eth2_aramus_crown(P_obj obj, P_char ch, int cmd, char *arg)
 		else
 			return FALSE;
 
-		curr_time = time(NULL);
+		curr_time = get_time();
 
 		if (obj->timer[0] + 10 <= curr_time)
 		{

--- a/src/specs.highway.c
+++ b/src/specs.highway.c
@@ -135,7 +135,7 @@ int amethyst_orb(P_obj obj, P_char ch, int cmd, char *arg)
 
 	if (cmd == CMD_STARE)
 	{
-		int curr_time = time(NULL);
+		int curr_time = get_time();
 
 		if (!obj->value[0])
 		{

--- a/src/specs.hoa.c
+++ b/src/specs.hoa.c
@@ -163,7 +163,7 @@ int illesarus(P_obj obj, P_char ch, int cmd, char *arg)
 		return FALSE;
 	}
 
-	curr_time = time(NULL);
+	curr_time = get_time();
 
 	if (!has_skin_spell(ch) && obj->timer[0] + (int)get_property("timer.stoneskin.generic", 60) <= curr_time)
 	{

--- a/src/specs.ioun.c
+++ b/src/specs.ioun.c
@@ -49,7 +49,7 @@ int ioun_sustenance(P_obj obj, P_char ch, int cmd, char *argument)
 	{
 		if (isname(argument, "feedme"))
 		{
-			int curr_time = time(NULL);
+			int curr_time = get_time();
 
 			if (curr_time >= obj->timer[0] + 60)
 			{
@@ -72,7 +72,7 @@ int ioun_sustenance(P_obj obj, P_char ch, int cmd, char *argument)
 
 int ioun_testicle(P_obj obj, P_char ch, int cmd, char *argument)
 {
-	int    current_time = time(NULL);
+	int    current_time = get_time();
 	P_char next, target, vict;
 	P_obj  pobj, x;
 	int    i;
@@ -175,7 +175,7 @@ int ioun_warp(P_obj obj, P_char ch, int cmd, char *argument)
 	P_char next, target, vict;
 	int    dam;
 
-	int curr_time = time(NULL);
+	int curr_time = get_time();
 	;
 
 	if (cmd == CMD_SET_PERIODIC)

--- a/src/specs.jot.c
+++ b/src/specs.jot.c
@@ -49,7 +49,7 @@ int icicle_cloak(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "icicle"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 
 			if (curr_time >= obj->timer[0] + 60)
 			{
@@ -328,7 +328,7 @@ int deva_cloak(P_obj obj, P_char ch, int cmd, char *arg)
 		return FALSE;
 	}
 
-	curr_time = time(NULL);
+	curr_time = get_time();
 	if (!IS_ROOM(ch->in_room, ROOM_NO_MAGIC))
 	{
 		if ((obj->timer[0] + 360) <= curr_time)
@@ -600,7 +600,7 @@ int reliance_pegasus(P_obj obj, P_char ch, int cmd, char *arg)
 				return TRUE;
 			}
 
-			curr_time = time(NULL);
+			curr_time = get_time();
 
 			if (obj->timer[0] + 200 <= curr_time)
 			{

--- a/src/specs.juiblex.c
+++ b/src/specs.juiblex.c
@@ -189,7 +189,7 @@ int ebb_vambraces(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "ebb"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 
 			if (obj->timer[0] + 600 <= curr_time)
 			{
@@ -251,7 +251,7 @@ int flow_amulet(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "flow"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 			// 5 min 50 sec timer ?!?
 			if (obj->timer[0] + 350 <= curr_time)
 			{
@@ -312,7 +312,7 @@ int juiblex_grid_mob_generator(P_obj obj, P_char ch, int cmd, char *arg)
 
 	if (cmd == CMD_PERIODIC)
 	{
-		int curr_time = time(NULL);
+		int curr_time = get_time();
 
 		if (curr_time < obj->timer[0] + 180)
 			return FALSE;

--- a/src/specs.lohrr.c
+++ b/src/specs.lohrr.c
@@ -141,7 +141,7 @@ int sphinx_prefect_crown(P_obj obj, P_char ch, int cmd, char *arg)
 		return FALSE;
 	}
 
-	curr_time = time(NULL);
+	curr_time = get_time();
 
 	if (arg && (cmd == CMD_SAY) && isname(arg, "sphinx"))
 	{
@@ -356,13 +356,13 @@ int proc_soldon_hat(P_obj obj, P_char ch, int cmd, char *argument)
 	}
 
 	// 5 min timer.
-	if (time(NULL) < timer + 300)
+	if (get_time() < timer + 300)
 	{
 		send_to_char("&+yYou rub the brim of your hat, but nothing happens..&n\n\r", ch);
 		return TRUE;
 	}
 	// Reset timer.
-	timer = time(NULL);
+	timer = get_time();
 
 	count = 4;
 	// Load count deck hands.

--- a/src/specs.lucrot.c
+++ b/src/specs.lucrot.c
@@ -31,7 +31,7 @@ extern P_room  world;
 
 int lucrot_mindstone(P_obj obj, P_char ch, int cmd, char *arg)
 {
-	int curr_time = time(NULL);
+	int curr_time = get_time();
 
 	if (cmd == CMD_SET_PERIODIC)
 	{
@@ -58,7 +58,7 @@ int lucrot_mindstone(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "journey"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 
 			if (affected_by_spell(ch, TAG_PVPDELAY) || IS_FIGHTING(ch) || IS_IMMOBILE(ch))
 			{

--- a/src/specs.mobile.c
+++ b/src/specs.mobile.c
@@ -10408,7 +10408,7 @@ int world_quest(P_char ch, P_char pl, int cmd, char *arg)
 
 			temp = (int)((get_property("world.quest.abandon.mod", 1.0) * GET_LEVEL(pl) * GET_LEVEL(pl) * GET_LEVEL(pl)));
 
-			timediff = time(NULL) - pl->only.pc->quest_started;
+			timediff = get_time() - pl->only.pc->quest_started;
 			// debug("timediff: %f", timediff);
 			costmod = 1.0 - (timediff / 60.0 / 60.0 / get_property("world.quest.cost.abandon.time", 24.000));
 			costmod *= 100;
@@ -13363,7 +13363,7 @@ int io_assistant(P_char ch, P_char pl, int cmd, char *arg)
 
 	// something is whacked with the random number generator, so adding some code to ensure a quiet
 	// time...  don't spam poor vareena with whispers!  Max of 1 per 15 minutes
-	if (chVar && (time(0) > (lastWhisper + (15 * 60))))
+	if (chVar && (get_time() > (lastWhisper + (15 * 60))))
 	{
 		switch (number(1, 100))
 		{
@@ -13392,7 +13392,7 @@ int io_assistant(P_char ch, P_char pl, int cmd, char *arg)
 				return FALSE;
 		}
 		act("$n whispers something to $N.", FALSE, ch, 0, chVar, TO_NOTVICT);
-		lastWhisper = time(0);
+		lastWhisper = get_time();
 		return TRUE;
 		;
 	}

--- a/src/specs.object.c
+++ b/src/specs.object.c
@@ -383,7 +383,7 @@ int artifact_biofeedback(P_obj obj, P_char ch, int cmd, char *argument)
 		return FALSE;
 	}
 
-	curr_time = time(NULL);
+	curr_time = get_time();
 
 	if (obj->timer[0] + get_property("timer.bioIoun", 80) <= curr_time && !has_skin_spell(temp_ch))
 	{
@@ -435,7 +435,7 @@ int artifact_stone(P_obj obj, P_char ch, int cmd, char *argument)
 		return FALSE;
 	}
 
-	curr_time = time(NULL);
+	curr_time = get_time();
 
 	if (!has_skin_spell(ch) && obj->timer[0] + (int)get_property("timer.stoneskin.generic", 60) <= curr_time)
 	{
@@ -482,7 +482,7 @@ int artifact_shadow_shield(P_obj obj, P_char ch, int cmd, char *argument)
 		}
 	}
 
-	curr_time = time(NULL);
+	curr_time = get_time();
 
 	if (!has_skin_spell(ch) && obj->timer[0] + (int)get_property("timer.stoneskin.generic", 60) <= curr_time)
 	{
@@ -531,12 +531,12 @@ int charon_ship(P_obj obj, P_char ch, int cmd, char *argument)
 
 	if (!(obj->timer[0]))
 	{
-		obj->timer[0] = time(NULL);
+		obj->timer[0] = get_time();
 	}
 
 	if (OBJ_ROOM(obj))
 	{
-		curr_time = time(NULL);
+		curr_time = get_time();
 		switch (obj->timer[1])
 		{
 			// Beginning state, docked.
@@ -544,7 +544,7 @@ int charon_ship(P_obj obj, P_char ch, int cmd, char *argument)
 				// If 1 minute has passed..
 				if (curr_time > obj->timer[0] + (1 * 60))
 				{
-					obj->timer[0] = time(NULL);
+					obj->timer[0] = get_time();
 					obj->timer[1] = 1;
 					send_to_room("&+LA spectral galleon hoists its anchor, preparing to depart.\n", obj->loc.room);
 				}
@@ -554,7 +554,7 @@ int charon_ship(P_obj obj, P_char ch, int cmd, char *argument)
 				// If 30 sec have passed..
 				if (curr_time > obj->timer[0] + (30))
 				{
-					obj->timer[0] = time(NULL);
+					obj->timer[0] = get_time();
 					if (obj->timer[2])
 					{
 						obj->timer[1] = 3;
@@ -570,7 +570,7 @@ int charon_ship(P_obj obj, P_char ch, int cmd, char *argument)
 				if (galleon_route[obj->timer[2] + 1] == -1)
 				{
 					obj->timer[1] = 4;
-					obj->timer[0] = time(NULL);
+					obj->timer[0] = get_time();
 					send_to_room("&+LA spectral galleon drops its anchor.\n", obj->loc.room);
 					spill = 1;
 				}
@@ -588,7 +588,7 @@ int charon_ship(P_obj obj, P_char ch, int cmd, char *argument)
 				if (!(obj->timer[2]))
 				{
 					obj->timer[1] = 4;
-					obj->timer[0] = time(NULL);
+					obj->timer[0] = get_time();
 					send_to_room("&+LA spectral galleon drops its anchor.\n", obj->loc.room);
 					spill = 1;
 				}
@@ -605,7 +605,7 @@ int charon_ship(P_obj obj, P_char ch, int cmd, char *argument)
 			case 4:
 				if (curr_time > obj->timer[0] + (30))
 				{
-					obj->timer[0] = time(NULL);
+					obj->timer[0] = get_time();
 					obj->timer[1] = 0;
 				}
 				break;
@@ -687,7 +687,7 @@ int pathfinder(P_obj obj, P_char ch, int cmd, char *argument)
 			{
 				return TRUE;
 			}
-			curr_time = time(NULL);
+			curr_time = get_time();
 
 			// Every 800 sec.
 			if (obj->timer[0] + 800 <= curr_time)
@@ -739,7 +739,7 @@ int artifact_hide(P_obj obj, P_char ch, int cmd, char *argument)
 			if (!say(ch, arg))
 				return TRUE;
 
-			curr_time = time(NULL);
+			curr_time = get_time();
 
 			if (obj->timer[0] + 60 <= curr_time)
 			{
@@ -804,7 +804,7 @@ int artifact_invisible(P_obj obj, P_char ch, int cmd, char *argument)
 			if (!say(ch, arg))
 				return TRUE;
 
-			curr_time = time(NULL);
+			curr_time = get_time();
 
 			if (obj->timer[0] + 60 <= curr_time)
 			{
@@ -841,7 +841,7 @@ int transp_tow_misty_gloves(P_obj obj, P_char ch, int cmd, char *argument)
 			{
 				return FALSE;
 			}
-			curr_time = time(NULL);
+			curr_time = get_time();
 			// Every 30 sec.
 			if (obj->timer[0] + 30 <= curr_time && !has_skin_spell(ch))
 			{
@@ -863,7 +863,7 @@ int transp_tow_misty_gloves(P_obj obj, P_char ch, int cmd, char *argument)
 
 	if (argument && (cmd == CMD_RUB))
 	{
-		curr_time = time(NULL);
+		curr_time = get_time();
 
 		act("You rub your gloved hands together.", FALSE, ch, 0, 0, TO_CHAR);
 		act("$n rubs $s gloved hands together.", FALSE, ch, 0, 0, TO_ROOM);
@@ -1957,7 +1957,7 @@ int xmas_cap(P_obj obj, P_char ch, int cmd, char *arg)
 {
 	struct proc_data *data;
 	P_char            victim;
-	int               curr_time = time(NULL);
+	int               curr_time = get_time();
 
 	if (cmd == CMD_SET_PERIODIC)
 	{
@@ -2094,7 +2094,7 @@ int bloodfeast(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (OBJ_WORN(obj) && obj->loc.wearing == ch)
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 			// Every 30 sec.
 			if (obj->timer[0] + 30 <= curr_time && !has_skin_spell(temp_ch))
 			{
@@ -2193,7 +2193,7 @@ void event_revenant_crown(P_char ch, P_char victim, P_obj obj, void *data)
 		ch->player.race = af->modifier;
 		//    GET_AGE(ch) = racial_data[(int) GET_RACE(ch)].base_age*2;
 		// Set birthdate + base_age + 5 years.
-		ch->player.time.birth = time(NULL);
+		ch->player.time.birth = get_time();
 		// Add base_age to birthdate + base_age + 5 years.
 		ch->player.time.birth -= (racial_data[GET_RACE(ch)].base_age) * SECS_PER_MUD_YEAR;
 		affect_remove(ch, af);
@@ -2291,7 +2291,7 @@ int revenant_helm(P_obj obj, P_char ch, int cmd, char *arg)
 
 	ch->player.race = RACE_REVENANT;
 	// Set birthdate + base_age + 5 years.
-	ch->player.time.birth = time(NULL);
+	ch->player.time.birth = get_time();
 	// Add base_age to birthdate + base_age + 5 years.
 	ch->player.time.birth -= (racial_data[RACE_REVENANT].base_age) * SECS_PER_MUD_YEAR;
 	return TRUE;
@@ -2345,10 +2345,10 @@ void event_dragonlord_check(P_char ch, P_char victim, P_obj obj, void *data)
 	else
 	{
 		ch->player.race       = af->modifier;
-		ch->player.time.birth = time(NULL) - (racial_data[GET_RACE(ch)].base_age) * 2;
+		ch->player.time.birth = get_time() - (racial_data[GET_RACE(ch)].base_age) * 2;
 		//    GET_AGE(ch) = racial_data[(int) GET_RACE(ch)].base_age*2;
 		// Set birthdate + base_age + 5 years.
-		ch->player.time.birth = time(NULL);
+		ch->player.time.birth = get_time();
 		// Add base_age to birthdate + base_age + 5 years.
 		ch->player.time.birth -= (racial_data[GET_RACE(ch)].base_age) * SECS_PER_MUD_YEAR;
 		affect_remove(ch, af);
@@ -2451,10 +2451,10 @@ int dragonlord_plate_old(P_obj obj, P_char ch, int cmd, char *arg)
 
 			temp_ch->player.race = RACE_DRAGONKIN;
 
-			temp_ch->player.time.birth = time(NULL) - (racial_data[RACE_DRAGONKIN].base_age) * 2;
+			temp_ch->player.time.birth = get_time() - (racial_data[RACE_DRAGONKIN].base_age) * 2;
 			//      GET_AGE(temp_ch) += racial_data[RACE_DRAGONKIN].base_age * 2;
 			// Set birthdate + base_age + 5 years.
-			temp_ch->player.time.birth = time(NULL);
+			temp_ch->player.time.birth = get_time();
 			// Add base_age to birthdate + base_age + 5 years.
 			temp_ch->player.time.birth -= (racial_data[RACE_DRAGONKIN].base_age) * SECS_PER_MUD_YEAR;
 
@@ -2475,7 +2475,7 @@ int dragonlord_plate(P_obj obj, P_char ch, int cmd, char *arg)
 
 	if (cmd == CMD_PERIODIC && OBJ_WORN(obj) && (ch = obj->loc.wearing) && IS_ALIVE(obj->loc.wearing))
 	{
-		curr_time = time(NULL);
+		curr_time = get_time();
 		// Every 30 min.
 		if (obj->timer[1] + 1800 <= curr_time && !IS_AFFECTED4(ch, AFF4_STORNOGS_SPHERES))
 		{
@@ -2515,7 +2515,7 @@ int dragonlord_plate_oldold(P_obj obj, P_char ch, int cmd, char *arg)
 		if (OBJ_WORN(obj))
 		{
 			temp_ch   = obj->loc.wearing;
-			curr_time = time(NULL);
+			curr_time = get_time();
 
 			if (obj->timer[1] + 1800 <= curr_time && !IS_AFFECTED4(temp_ch, AFF4_STORNOGS_SPHERES))
 			{
@@ -2551,7 +2551,7 @@ int olympus_portal(P_obj obj, P_char ch, int cmd, char *arg)
 	}
 
 	// Every 30 sec..
-	if (!obj || cmd != CMD_PERIODIC || obj->timer[0] + 30 > time(NULL))
+	if (!obj || cmd != CMD_PERIODIC || obj->timer[0] + 30 > get_time())
 	{
 		return FALSE;
 	}
@@ -2604,7 +2604,7 @@ int olympus_portal(P_obj obj, P_char ch, int cmd, char *arg)
 				portal->value[0] = world[obj->loc.room].number;
 			}
 		}
-		obj->timer[0] = time(NULL);
+		obj->timer[0] = get_time();
 		return TRUE;
 	}
 
@@ -2788,7 +2788,7 @@ int vapor(P_obj obj, P_char ch, int cmd, char *arg)
 	/*
 	  Damage proc on.
 	*/
-	curr_time = time(NULL);
+	curr_time = get_time();
 	if (obj->timer[1] + 30 < curr_time)
 	{
 		if (IS_FIGHTING(ch) && OBJ_WORN(obj))
@@ -3031,7 +3031,7 @@ int golem_chunk(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "slow"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 			// Every 24 minutes?
 			if (obj->timer[0] + (60 * 24) <= curr_time)
 			{
@@ -3070,7 +3070,7 @@ int good_evil_stoneOrSoulshield(P_obj obj)
 		if (!IS_AFFECTED2(temp_ch, AFF2_SOULSHIELD))
 			spell_soulshield(55, temp_ch, 0, SPELL_TYPE_SPELL, temp_ch, 0);
 	}
-	curr_time = time(NULL);
+	curr_time = get_time();
 	if (obj->timer[0] + 10 <= curr_time && !has_skin_spell(temp_ch))
 	{
 		spell_stone_skin(55, temp_ch, 0, SPELL_TYPE_SPELL, temp_ch, 0);
@@ -3854,7 +3854,7 @@ int sunblade(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (OBJ_WORN(obj) && (ch = obj->loc.wearing))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 
 			if (!has_skin_spell(ch) && obj->timer[0] + (int)get_property("timer.stoneskin.artifact.sunblade", 30) <= curr_time)
 			{
@@ -4255,7 +4255,7 @@ int sanguine(P_obj obj, P_char ch, int cmd, char *argument)
 			{
 				return TRUE;
 			}
-			curr_time = time(NULL);
+			curr_time = get_time();
 
 			// 5 min timer.
 			if (obj->timer[0] + 300 <= curr_time)
@@ -6413,10 +6413,10 @@ int wall_generic(P_obj obj, P_char ch, int cmd, char *arg)
 	if (type == WATCHING_WALL && cmd >= 1 && cmd < 1000)
 	{
 
-		if (obj->loc_p == LOC_ROOM && ch && !IS_TRUSTED(ch) && (time(NULL) - obj->value[6]) > 10)
+		if (obj->loc_p == LOC_ROOM && ch && !IS_TRUSTED(ch) && (get_time() - obj->value[6]) > 10)
 		{
 
-			obj->value[6] = time(NULL);
+			obj->value[6] = get_time();
 
 			for (illusionist = character_list; illusionist; illusionist = illusionist->next)
 				if (IS_PC(illusionist) && GET_PID(illusionist) == obj->value[5])
@@ -7125,7 +7125,7 @@ int zarbon_shaper(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "blink"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 
 			if (obj->timer[1] + number(1, 5) <= curr_time)
 			{
@@ -7141,7 +7141,7 @@ int zarbon_shaper(P_obj obj, P_char ch, int cmd, char *arg)
 		}
 		else if (isname(arg, "deflect"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 
 			if (obj->timer[2] + 500 <= curr_time)
 			{
@@ -7160,7 +7160,7 @@ int zarbon_shaper(P_obj obj, P_char ch, int cmd, char *arg)
 		else
 			return FALSE;
 	}
-	curr_time = time(NULL);
+	curr_time = get_time();
 
 	if (obj->timer[0] + number(1, 30) <= curr_time)
 	{
@@ -7411,7 +7411,7 @@ int trans_tower_sword(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "stone"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 
 			if (obj->timer[0] + 60 <= curr_time)
 			{
@@ -7452,7 +7452,7 @@ int trans_tower_sword(P_obj obj, P_char ch, int cmd, char *arg)
 int trans_tower_shadow_globe(P_obj obj, P_char ch, int cmd, char *arg)
 {
 	P_char vict;
-	int    curr_time = time(NULL);
+	int    curr_time = get_time();
 
 	if (cmd == CMD_SET_PERIODIC)
 		return TRUE;
@@ -7515,7 +7515,7 @@ int trans_tower_shadow_globe(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "invisible"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 
 			if (obj->timer[0] + 60 <= curr_time)
 			{
@@ -7649,7 +7649,7 @@ int stat_pool_common(P_obj obj, P_char ch, int cmd, sh_int *statPtr, const char 
 
 			if ((af2 = get_spell_from_char(ch, TAG_POOL)) != NULL)
 			{
-				if ((af2->modifier + (60 * 60 * 24 * 2)) > time(NULL))
+				if ((af2->modifier + (60 * 60 * 24 * 2)) > get_time())
 				{
 					send_to_char("The liquid burns your throat!  Ouch!\n", ch);
 					act("$n reels in pain as $e takes a drink from $p!", FALSE, ch, obj, 0, TO_ROOM);
@@ -7675,7 +7675,7 @@ int stat_pool_common(P_obj obj, P_char ch, int cmd, sh_int *statPtr, const char 
 	af.flags = AFFTYPE_STORE | AFFTYPE_PERM;
 	// af.duration = (int) (get_property("timer.mins.statPool", SECS_PER_REAL_HOUR * 24));
 	af.duration = -1;
-	af.modifier = time(NULL);
+	af.modifier = get_time();
 	affect_to_char(ch, &af);
 
 	act("$n takes a drink from $p.", FALSE, ch, obj, 0, TO_ROOM);
@@ -7732,7 +7732,7 @@ int spell_pool(P_obj obj, P_char ch, int cmd, char *arg)
 
 	if (cmd == CMD_SET_PERIODIC)
 	{
-		curr_time = time(NULL);
+		curr_time = get_time();
 
 		obj->value[0] = rannum;
 		obj->timer[0] = curr_time;
@@ -7742,7 +7742,7 @@ int spell_pool(P_obj obj, P_char ch, int cmd, char *arg)
 
 	spell_func = spells[obj->value[0]];
 
-	curr_time = time(NULL);
+	curr_time = get_time();
 
 	if (obj->timer[0] + (60 * 40) <= curr_time)
 	{
@@ -8059,7 +8059,7 @@ int splinter(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "splinter"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 			// Every 15 minutes.
 			if (obj->timer[0] + (60 * 15) <= curr_time)
 			{
@@ -8094,7 +8094,7 @@ int church_door(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "glass"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 
 			if (obj->timer[0] + 15 <= curr_time && !affected_by_spell(ch, SPELL_ARMOR))
 			{
@@ -8234,7 +8234,7 @@ int staff_of_air_conjuration(P_obj obj, P_char ch, int cmd, char *arg)
 		return TRUE;
 	}
 
-	curr_time = time(NULL);
+	curr_time = get_time();
 
 	if (cmd == CMD_PERIODIC)
 	{
@@ -8309,7 +8309,7 @@ int serpent_of_miracles(P_obj obj, P_char ch, int cmd, char *arg)
 		return FALSE;
 	}
 
-	curr_time = time(NULL);
+	curr_time = get_time();
 	if (arg && (cmd == CMD_SAY))
 	{
 		if (isname(arg, "wish"))
@@ -8966,7 +8966,7 @@ int guild_badge(P_obj obj, P_char ch, int cmd, char *arg)
 		return FALSE;
 	}
 
-	curr_time = time(NULL);
+	curr_time = get_time();
 	if (obj->timer[0] <= curr_time)
 	{
 		// Things breaks sometimes...
@@ -9918,7 +9918,7 @@ int dragon_skull_helm(P_obj obj, P_char ch, int cmd, char *argument)
 		return FALSE;
 	}
 
-	curr_time = time(NULL);
+	curr_time = get_time();
 	if (!IS_ROOM(ch->in_room, ROOM_NO_MAGIC))
 	{
 		// 1 min timer.
@@ -10004,7 +10004,7 @@ int priest_rudder(P_obj obj, P_char ch, int cmd, char *argument)
 		return FALSE;
 	}
 
-	curr_time = time(NULL);
+	curr_time = get_time();
 	// 2 min timer.
 	if (obj->timer[0] + 120 <= curr_time)
 	{
@@ -10111,7 +10111,7 @@ int alch_bag(P_obj obj, P_char ch, int cmd, char *arg)
 		return FALSE;
 	}
 
-	curr_time = time(NULL);
+	curr_time = get_time();
 	if (obj->timer[0] + 60 + number(0, 30) <= curr_time)
 	{
 		/* if this somehow works, it is a MIRACLE as I had nothing to copy from */
@@ -10521,7 +10521,7 @@ int out_of_god_bp(P_obj obj, P_char ch, int cmd, char *arg)
 
 int ring_of_regeneration(P_obj obj, P_char ch, int cmd, char *arg)
 {
-	int  curr_time = time(NULL);
+	int  curr_time = get_time();
 	char first_arg[256];
 
 	if (cmd == CMD_SET_PERIODIC)
@@ -10565,7 +10565,7 @@ int ring_of_regeneration(P_obj obj, P_char ch, int cmd, char *arg)
 
 int proc_whirlwinds(P_obj obj, P_char ch, int cmd, char *arg)
 {
-	int curr_time = time(NULL);
+	int curr_time = get_time();
 
 	if (cmd == CMD_SET_PERIODIC)
 	{
@@ -10661,7 +10661,7 @@ int glowing_necklace(P_obj obj, P_char ch, int cmd, char *arg)
 				send_to_char("You're too busy fighting for your life to reach up for your necklace.\n", ch);
 				return FALSE;
 			}
-			curr_time = time(NULL);
+			curr_time = get_time();
 			if ((((obj->timer[0] + (60 * 3)) + number(0, 120)) <= curr_time) || IS_TRUSTED(ch))
 			{
 				// Raise to 100 if you want spec pets to occur
@@ -10846,7 +10846,7 @@ int staff_shadow_summoning(P_obj obj, P_char ch, int cmd, char *arg)
 				send_to_char("You're too busy fighting for your life to worry about that.\n", ch);
 				return FALSE;
 			}
-			curr_time = time(NULL);
+			curr_time = get_time();
 			if (!IS_TRUSTED(ch))
 			{
 				if (obj->value[7] > 100)
@@ -11022,7 +11022,7 @@ int blood_stains(P_obj obj, P_char ch, int cmd, char *argument)
 	// Set the timer when obj is loaded
 	if (cmd == CMD_SET_PERIODIC)
 	{
-		obj->timer[0] = time(NULL);
+		obj->timer[0] = get_time();
 		return TRUE;
 	}
 
@@ -11035,14 +11035,14 @@ int blood_stains(P_obj obj, P_char ch, int cmd, char *argument)
 	if (cmd == CMD_PERIODIC && obj->value[1] < BLOOD_DRY)
 	{
 		// Change it up after 90 seconds
-		if (!IS_SET(obj->extra_flags, ITEM_NOSHOW) && (obj->timer[0] < (time(NULL) - 90)))
+		if (!IS_SET(obj->extra_flags, ITEM_NOSHOW) && (obj->timer[0] < (get_time() - 90)))
 		{
 			SET_BIT(obj->extra_flags, ITEM_NOSHOW);
 			return TRUE;
 		}
 
 		// Change it up after 3 minutes
-		if ((obj->value[1] == BLOOD_FRESH) && (obj->timer[0] < (time(NULL) - 180)))
+		if ((obj->value[1] == BLOOD_FRESH) && (obj->timer[0] < (get_time() - 180)))
 		{
 			snprintf(buf, MAX_STRING_LENGTH, "%s", long_desc_reg[obj->value[0]]);
 			obj->description = str_dup(buf);
@@ -11051,7 +11051,7 @@ int blood_stains(P_obj obj, P_char ch, int cmd, char *argument)
 		}
 
 		// Change it up after 7 minutes
-		if ((obj->value[1] == BLOOD_REG) && (obj->timer[0] < (time(NULL) - 420)))
+		if ((obj->value[1] == BLOOD_REG) && (obj->timer[0] < (get_time() - 420)))
 		{
 			snprintf(buf, MAX_STRING_LENGTH, "%s", long_desc_dry[obj->value[0]]);
 			obj->description = str_dup(buf);
@@ -11376,7 +11376,7 @@ int lyrical_instrument_of_time(P_obj obj, P_char ch, int cmd, char *argument)
 	if (!(obj == temp_ch->equipment[HOLD]))
 		return FALSE;
 
-	curr_time = time(NULL);
+	curr_time = get_time();
 
 	if (!IS_ROOM(temp_ch->in_room, ROOM_NO_MAGIC))
 	{
@@ -11648,7 +11648,7 @@ int mace_dragondeath(P_obj obj, P_char ch, int cmd, char *arg)
 
 	if (cmd == CMD_PERIODIC && !IS_ROOM(temp_ch->in_room, ROOM_NO_MAGIC))
 	{
-		curr_time = time(NULL);
+		curr_time = get_time();
 
 		if (obj->timer[0] + 60 <= curr_time)
 		{
@@ -12495,10 +12495,10 @@ void apply_zone_spell(P_char ch, int count, const char *zone_name, int zone_inde
 			}
 			break;
 		case SPELL_STONE_SKIN:
-			if (!has_skin_spell(ch) && obj->timer[0] + get_property("timer.stoneskin.generic", 60) < time(NULL))
+			if (!has_skin_spell(ch) && obj->timer[0] + get_property("timer.stoneskin.generic", 60) < get_time())
 			{
 				spell_stone_skin(count * 5, ch, 0, 0, ch, 0);
-				obj->timer[0] = time(NULL);
+				obj->timer[0] = get_time();
 				message       = SETMSG_PROTECT;
 			}
 			break;
@@ -12543,18 +12543,18 @@ void apply_zone_spell(P_char ch, int count, const char *zone_name, int zone_inde
 			}
 			break;
 		case SPELL_CONJURE_ELEMENTAL:
-			if (obj->timer[0] + get_property("timer.conjureElement.generic", 300) < time(NULL))
+			if (obj->timer[0] + get_property("timer.conjureElement.generic", 300) < get_time())
 			{
 				(skills[spell].spell_pointer)(MAX(30, count * 10), ch, 0, 0, ch, 0);
-				obj->timer[0] = time(NULL);
+				obj->timer[0] = get_time();
 				message       = SETMSG_STRENGTH;
 			}
 			break;
 		case SPELL_INVIGORATE:
-			if (obj->timer[0] + get_property("timer.invigorate.generic", 60) < time(NULL) && GET_VITALITY(ch) < GET_MAX_VITALITY(ch))
+			if (obj->timer[0] + get_property("timer.invigorate.generic", 60) < get_time() && GET_VITALITY(ch) < GET_MAX_VITALITY(ch))
 			{
 				(skills[spell].spell_pointer)(MAX(30, count * 10), ch, 0, 0, ch, 0);
-				obj->timer[0] = time(NULL);
+				obj->timer[0] = get_time();
 				message       = SETMSG_STRENGTH;
 			}
 			break;
@@ -13054,7 +13054,7 @@ int bel_sword(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "eld"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 			// 4 min timer.
 			if (obj->timer[0] + 240 <= curr_time)
 			{
@@ -13427,14 +13427,14 @@ int portal_general_internal(P_obj obj, P_char ch, int cmd, char *arg, struct por
 	//--------------------------------
 	// check timers
 	// 1. initial stabilization
-	if ((obj->value[4] > 0) && (time(0) - obj->timer[0]) < obj->value[4])
+	if ((obj->value[4] > 0) && (get_time() - obj->timer[0]) < obj->value[4])
 	{
 		send_to_char(msg->wait_init_to_char, ch);
 		return TRUE;
 	}
 
 	// 2. post enter stabilization
-	if (obj->timer[1] > 0 && obj->value[5] > 0 && (time(0) - obj->timer[1]) < obj->value[5])
+	if (obj->timer[1] > 0 && obj->value[5] > 0 && (get_time() - obj->timer[1]) < obj->value[5])
 	{
 		send_to_char(msg->wait_to_char, ch);
 		return TRUE;
@@ -13472,7 +13472,7 @@ int portal_general_internal(P_obj obj, P_char ch, int cmd, char *arg, struct por
 
 	//------------------------
 	// reset enter stabilization as someone entered
-	obj->timer[1] = time(0);
+	obj->timer[1] = get_time();
 	//------------------------
 
 	// add lag after step out from portal
@@ -13542,7 +13542,7 @@ int mentality_mace(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "mentality"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 			// 5 min timer.
 			if (IS_TRUSTED(ch) || (obj->timer[0] + 300 <= curr_time))
 			{
@@ -13716,7 +13716,7 @@ int resurrect_totem(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "ilienze"))
 		{
-			int curr_time = time(NULL);
+			int curr_time = get_time();
 			// 1 rl hour timer.
 			if (IS_TRUSTED(ch) || (obj->timer[0] + 3600 <= curr_time))
 			{
@@ -13789,7 +13789,7 @@ int blue_sword_armor(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "armor"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 
 			if (curr_time >= obj->timer[0] + 60)
 			{
@@ -13850,7 +13850,7 @@ int jet_black_maul(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "titan"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 
 			if (curr_time >= obj->timer[0] + 60)
 			{
@@ -14133,7 +14133,7 @@ int miners_helmet(P_obj obj, P_char ch, int cmd, char *argument)
 		if (!strcmp(arg, "paydirt"))
 		{
 
-			curr_time = time(NULL);
+			curr_time = get_time();
 
 			// 10 minute timer = 600 sec.
 			if (obj->timer[0] + 600 <= curr_time)
@@ -14176,7 +14176,7 @@ int thanksgiving_wings(P_obj obj, P_char ch, int cmd, char *argument)
 		}
 	}
 
-	curr_time = time(NULL);
+	curr_time = get_time();
 
 	if (obj->timer[0] + (int)200 <= curr_time)
 	{

--- a/src/specs.ravenloft.c
+++ b/src/specs.ravenloft.c
@@ -336,7 +336,7 @@ int shimmer_shortsword(P_obj obj, P_char ch, int cmd, char *arg)
 		return FALSE;
 	}
 
-	curr_time = time(NULL);
+	curr_time = get_time();
 
 	if (!IS_ROOM(ch->in_room, ROOM_NO_MAGIC))
 	{

--- a/src/specs.room.c
+++ b/src/specs.room.c
@@ -374,7 +374,7 @@ int inn(int room, P_char ch, int cmd, char *arg)
 			*/
 			return TRUE;
 		}
-		ct = time(NULL);
+		ct = get_time();
 		// Convert to EST. - this sux.. gotta be a be'er way.
 		ct -= 4 * 60 * 60;
 		snprintf(timestr, MAX_STRING_LENGTH, "%s", asctime(localtime(&ct)));
@@ -917,7 +917,7 @@ int pet_shops(int room, P_char ch, int cmd, char *arg)
 			ticket->value[0]          = mount_rent_cost(mount);
 			ticket->value[1]          = GET_IDNUM(mount);
 			ticket->value[2]          = world[ch->in_room].number;
-			ticket->value[3]          = time(NULL);
+			ticket->value[3]          = get_time();
 
 			act("A stable-hand hands you a ticket, saying 'Pay when ya pick up.'", FALSE, ch, 0, 0, TO_CHAR);
 			act("A stable-hand hands $n a ticket, saying 'Pay when ya pick up.'", FALSE, ch, 0, 0, TO_ROOM);
@@ -962,7 +962,7 @@ int pet_shops(int room, P_char ch, int cmd, char *arg)
 		}
 #if 0
     /* This is cost per real life day */
-    val = ((ticket->value[3] - time(NULL) / SECS_PER_REAL_DAY) * ticket->value[0]);
+    val = ((ticket->value[3] - get_time() / SECS_PER_REAL_DAY) * ticket->value[0]);
 #else
 		/* and this is the flat rate price */
 		val = ticket->value[0];
@@ -1366,7 +1366,7 @@ int mortal_heaven(int room, P_char ch, int cmd, char *arg)
 		if (IS_TRUSTED(tch) || IS_NPC(tch))
 			continue;
 
-		if (tch->only.pc->pc_timer[PC_TIMER_HEAVEN] <= time(NULL))
+		if (tch->only.pc->pc_timer[PC_TIMER_HEAVEN] <= get_time())
 		{
 			send_to_char("Your soul is torn from the afterlife, eternal rest denied...\n\r", tch);
 			act("$n is torn from the afterlife.", FALSE, tch, 0, 0, TO_ROOM);

--- a/src/specs.shabo.c
+++ b/src/specs.shabo.c
@@ -143,7 +143,7 @@ int flayed_mind_mask(P_obj obj, P_char ch, int cmd, char *argument)
 				return TRUE;
 			}
 
-			curr_time = time(NULL);
+			curr_time = get_time();
 			// 30 min timer.
 			if (obj->timer[0] + 1800 <= curr_time)
 			{
@@ -184,7 +184,7 @@ int stalker_cloak(P_obj obj, P_char ch, int cmd, char *argument)
 			{
 				return TRUE;
 			}
-			curr_time = time(NULL);
+			curr_time = get_time();
 			// 3 min timer.
 			if (obj->timer[0] + 180 <= curr_time)
 			{
@@ -201,7 +201,7 @@ int stalker_cloak(P_obj obj, P_char ch, int cmd, char *argument)
 			{
 				return TRUE;
 			}
-			curr_time = time(NULL);
+			curr_time = get_time();
 			// 3 min timer.
 			if (obj->timer[0] + 180 <= curr_time)
 			{
@@ -218,7 +218,7 @@ int stalker_cloak(P_obj obj, P_char ch, int cmd, char *argument)
 			{
 				return TRUE;
 			}
-			curr_time = time(NULL);
+			curr_time = get_time();
 			// 1 min timer.
 			if (obj->timer[0] + 60 <= curr_time)
 			{
@@ -264,7 +264,7 @@ int finslayer_air(P_obj obj, P_char ch, int cmd, char *argument)
 				return TRUE;
 			}
 
-			curr_time = time(NULL);
+			curr_time = get_time();
 			// 1 min timer.
 			if (obj->timer[0] + 60 <= curr_time)
 			{
@@ -304,7 +304,7 @@ int aboleth_pendant(P_obj obj, P_char ch, int cmd, char *argument)
 		return FALSE;
 	}
 
-	curr_time = time(NULL);
+	curr_time = get_time();
 	// 900 for 15 mins
 	if (obj->timer[0] + 900 <= curr_time)
 	{
@@ -713,7 +713,7 @@ int mox_totem(P_obj obj, P_char ch, int cmd, char *argument)
 		return FALSE;
 	}
 
-	curr_time = time(NULL);
+	curr_time = get_time();
 
 	if (!IS_ROOM(ch->in_room, ROOM_NO_MAGIC))
 	{

--- a/src/specs.snogres.c
+++ b/src/specs.snogres.c
@@ -456,7 +456,7 @@ int flesh_golem_repop(P_obj obj, P_char ch, int cmd, char *arg)
 
 	if (cmd == CMD_PERIODIC)
 	{
-		int curr_time = time(NULL);
+		int curr_time = get_time();
 
 		if (curr_time < obj->timer[0] + 1)
 		{

--- a/src/specs.undermountain.c
+++ b/src/specs.undermountain.c
@@ -631,7 +631,7 @@ int staff_of_power(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "aura"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 
 			if (obj->timer[0] + 60 <= curr_time)
 			{
@@ -858,7 +858,7 @@ int staff_of_blue_flames(P_obj obj, P_char ch, int cmd, char *arg)
 		// Disabled gellz - 1/11/16 to enable use with globe of dark spell
 		//    if( !IS_OBJ_STAT(obj, ITEM_LIT) )
 		//     return FALSE;
-		curr_time = time(NULL);
+		curr_time = get_time();
 
 		if (isname(arg, "fly"))
 		{
@@ -961,7 +961,7 @@ int staff_of_blue_flames(P_obj obj, P_char ch, int cmd, char *arg)
 		}
 		else if (isname(arg, "stone"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 
 			act("You say 'stone' to $p.", FALSE, ch, obj, NULL, TO_CHAR);
 			act("&+bThe flames of your&N $q &+Bintensify.&N", FALSE, ch, obj, NULL, TO_CHAR);
@@ -978,7 +978,7 @@ int staff_of_blue_flames(P_obj obj, P_char ch, int cmd, char *arg)
 		}
 		else if (isname(arg, "globe"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 
 			act("You say 'globe' to $p.", FALSE, ch, obj, NULL, TO_CHAR);
 			act("&+bThe flames of your&N $q &+Bintensify.&N", FALSE, ch, obj, NULL, TO_CHAR);

--- a/src/specs.underworld.c
+++ b/src/specs.underworld.c
@@ -208,7 +208,7 @@ int dragonkind(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "protect me"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 			// 1 min timer.
 			if (obj->timer[0] + 60 <= curr_time)
 			{
@@ -437,7 +437,7 @@ int dragonkind(P_obj obj, P_char ch, int cmd, char *arg)
 
 int lightning(P_obj obj, P_char ch, int cmd, char *arg)
 {
-	int    current_time = time(NULL);
+	int    current_time = get_time();
 	P_char vict;
 
 	if (cmd == CMD_SET_PERIODIC)
@@ -705,7 +705,7 @@ int platemail_of_defense(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "stone"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 
 			if (curr_time >= obj->timer[0] + 60)
 			{
@@ -788,14 +788,14 @@ int flamberge(P_obj obj, P_char ch, int cmd, char *arg)
 		{
 			act("&+LYou whisper 'timeit' to $p&+L.", FALSE, ch, obj, NULL, TO_CHAR);
 			send_to_char_f(ch, "&+rFlamberge&n timer0 is: %10ld = %s", obj->timer[0], asctime(localtime(&obj->timer[0])));
-			curr_time = time(NULL) - obj->timer[0];
+			curr_time = get_time() - obj->timer[0];
 			send_to_char_f(ch, "  diff of timer0 is: %10ld = &+G%02d&+Lm &+G%02ld&+Ls&n\n", curr_time, curr_time / 60, curr_time % 60);
 			return TRUE;
 		}
 		if (!strcmp(arg, "efreeti") && OBJ_WORN_BY(obj, ch))
 		{
 			do_say(ch, arg, CMD_SAY);
-			curr_time = time(NULL);
+			curr_time = get_time();
 			if (obj->timer[0] + 300 <= curr_time)
 			{
 				if (GET_RACEWAR(ch) == RACEWAR_GOOD)
@@ -912,7 +912,7 @@ int doombringer(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "stone"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 			// 60 sec timer.
 			if (obj->timer[0] + 60 <= curr_time)
 			{
@@ -1062,7 +1062,7 @@ int mace(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "stone"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 
 			if (curr_time >= obj->timer[0] + 60)
 			{
@@ -1079,7 +1079,7 @@ int mace(P_obj obj, P_char ch, int cmd, char *arg)
 		}
 		else if (isname(arg, "invisible"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 
 			if (curr_time >= obj->timer[1] + 60)
 			{
@@ -1290,7 +1290,7 @@ int avernus(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "stone"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 
 			if (obj->timer[0] + 60 <= curr_time)
 			{
@@ -1350,7 +1350,7 @@ int purple_worm(P_char ch, P_char pl, int cmd, char *arg)
 		for (obj = ch->carrying; obj; obj = obj->next_content)
 		{
 			// 10% chance to poop a PC corpse. average digest time == 1 min + 5*6 sec == 1 1/2 min.
-			if (obj->type == ITEM_CORPSE && IS_SET(obj->value[1], PC_CORPSE) && obj->timer[0] < time(NULL) && !number(0, 9))
+			if (obj->type == ITEM_CORPSE && IS_SET(obj->value[1], PC_CORPSE) && obj->timer[0] < get_time() && !number(0, 9))
 			{
 				obj_from_char(obj);
 				obj_to_room(obj, ch->in_room);
@@ -1425,7 +1425,7 @@ int purple_worm(P_char ch, P_char pl, int cmd, char *arg)
 							{
 								writeCorpse(obj);
 								// Corpse is digested for a minute
-								obj->timer[0] = 60 + time(NULL);
+								obj->timer[0] = 60 + get_time();
 							}
 						}
 					}
@@ -2952,7 +2952,7 @@ int barb(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "power"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 			// 1 min timer.
 			if ((obj->timer[0] + 60 <= curr_time) && (GET_RACE(ch) == RACE_BARBARIAN))
 			{
@@ -3595,7 +3595,7 @@ int gfstone(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "stone"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 			// Every 1 min.
 			if (obj->timer[0] + 60 <= curr_time)
 			{
@@ -3848,7 +3848,7 @@ int SeaKingdom_Tsunami(P_obj obj, P_char ch, int cmd, char *arg)
 
 	if (arg && (isname(arg, "trident") || isname(arg, "tsunami")))
 	{
-		time_t curr_time = time(NULL);
+		time_t curr_time = get_time();
 
 		if (cmd == CMD_TAP)
 		{
@@ -4267,7 +4267,7 @@ int Einjar(P_obj obj, P_char ch, int cmd, char *arg)
 
 	if (cmd == CMD_SAY && arg && isname(arg, "Einjar"))
 	{
-		curr_time = time(NULL);
+		curr_time = get_time();
 		// 3 min timer.
 		if (obj->timer[0] + 180 <= curr_time)
 		{

--- a/src/specs.vecna.c
+++ b/src/specs.vecna.c
@@ -709,7 +709,7 @@ int vecna_staffoaken(P_obj obj, P_char ch, int cmd, char *arg)
 		}
 		else if (isname(arg, "freedom"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 			if (obj->timer[1] + 900 <= curr_time)
 			{
 				act("$n says 'freedom' to $p.", FALSE, ch, obj, 0, TO_ROOM);

--- a/src/specs.venthix.c
+++ b/src/specs.venthix.c
@@ -135,7 +135,7 @@ int roulette_pistol(P_obj obj, P_char ch, int cmd, char *arg)
 // 67282 &+mt&+Mh&+me &+Mo&+mr&+Mb &+mo&+Mf &+md&+Me&+mc&+Me&+mp&+Mt&+mi&+Mo&+mn
 int orb_of_deception(P_obj obj, P_char ch, int cmd, char *arg)
 {
-	int curr_time = time(NULL);
+	int curr_time = get_time();
 
 	if (cmd == CMD_SET_PERIODIC)
 	{
@@ -157,7 +157,7 @@ int orb_of_deception(P_obj obj, P_char ch, int cmd, char *arg)
 				act("&+L$n&+L's $p &+Lbegins to vibrate.", FALSE, ch, obj, 0, TO_ROOM);
 				act("&+LYour $p &+Lbegins to vibrate.", FALSE, ch, obj, 0, TO_CHAR);
 				spell_mirage(51, ch, 0, SPELL_TYPE_SPELL, ch, 0);
-				obj->timer[0] = time(NULL);
+				obj->timer[0] = get_time();
 				return TRUE;
 			}
 		}
@@ -624,7 +624,7 @@ int zombies_game(P_obj obj, P_char ch, int cmd, char *arg)
 				{
 					// set game to standby mode to setup the next round
 					obj->value[ZOMBIES_STATUS] = 2;
-					obj->timer[ZTIMER_STANDBY] = time(NULL);
+					obj->timer[ZTIMER_STANDBY] = get_time();
 					snprintf(buff, MAX_STRING_LENGTH, "&+WYou've completed round &+c%d&+W.  Prepare for the next round.&n\r\n", obj->value[ZOMBIES_LEVEL]);
 					send_to_zone(zone, buff);
 					return TRUE;
@@ -643,7 +643,7 @@ int zombies_game(P_obj obj, P_char ch, int cmd, char *arg)
 			else
 			{
 				// Load zombies!!!
-				if ((obj->timer[ZTIMER_WAVE] + (int)get_property("zombies.game.spawn.delay", 30) <= time(NULL)) || (!zombies && !number(0, 2)))
+				if ((obj->timer[ZTIMER_WAVE] + (int)get_property("zombies.game.spawn.delay", 30) <= get_time()) || (!zombies && !number(0, 2)))
 				{
 					obj->value[ZOMBIES_WAVE]++;
 					// Waves handling
@@ -677,7 +677,7 @@ int zombies_game(P_obj obj, P_char ch, int cmd, char *arg)
 					num = BOUNDED(1, num, zgame->zombies_to_load);
 					if (num)
 					{
-						obj->timer[ZTIMER_WAVE] = time(NULL);
+						obj->timer[ZTIMER_WAVE] = get_time();
 					}
 					debug("loading %d zombies", num);
 					for (int i = 0; i < num; i++)
@@ -694,7 +694,7 @@ int zombies_game(P_obj obj, P_char ch, int cmd, char *arg)
 		}
 		int delay = BOUNDED(10, (int)get_property("zombies.game.standby.delay", 15) * (obj->value[ZOMBIES_LEVEL] / 10), 120);
 		// If 2 minutes have passed and we are in standby mode begin next round
-		if (obj->value[ZOMBIES_STATUS] == 2 && (obj->timer[ZTIMER_STANDBY] + delay) <= time(NULL))
+		if (obj->value[ZOMBIES_STATUS] == 2 && (obj->timer[ZTIMER_STANDBY] + delay) <= get_time())
 		{
 			obj->timer[ZTIMER_STANDBY] = 0;
 			obj->timer[ZTIMER_WAVE]    = 0;
@@ -722,7 +722,7 @@ int zombies_game(P_obj obj, P_char ch, int cmd, char *arg)
 		{
 			// set game to standby mode to setup the next round
 			obj->value[ZOMBIES_STATUS] = 2;
-			obj->timer[ZTIMER_STANDBY] = time(NULL) - (10); // should be 10 seconds to start
+			obj->timer[ZTIMER_STANDBY] = get_time() - (10); // should be 10 seconds to start
 			send_to_zone(zone, "&+WThe game has started.&n\r\n");
 			return TRUE;
 		}

--- a/src/specs.winterhaven.c
+++ b/src/specs.winterhaven.c
@@ -193,7 +193,7 @@ int storm_legplates(P_obj obj, P_char ch, int cmd, char *arg)
 		{
 			if (isname(arg, "storm"))
 			{
-				curr_time = time(NULL);
+				curr_time = get_time();
 				vict      = GET_OPPONENT(ch);
 				// 10 min timer.
 				if (obj->timer[0] + 600 <= curr_time)
@@ -245,7 +245,7 @@ int storm_legplates(P_obj obj, P_char ch, int cmd, char *arg)
 		{
 			if (isname(arg, "storm"))
 			{
-				curr_time = time(NULL);
+				curr_time = get_time();
 				// 10 min timer.
 				if (OUTSIDE(ch) && obj->timer[0] + 600 <= curr_time)
 				{
@@ -268,7 +268,7 @@ int storm_legplates(P_obj obj, P_char ch, int cmd, char *arg)
 		{
 			if (isname(arg, "ground"))
 			{
-				curr_time = time(NULL);
+				curr_time = get_time();
 				if (obj->timer[0] + 600 <= curr_time)
 				{
 					act("$q &+wsends a burst of &+Yelectricity &+wthrough your body.&n", TRUE, ch, obj, obj, TO_CHAR);
@@ -316,7 +316,7 @@ int blur_shortsword(P_obj obj, P_char ch, int cmd, char *arg)
 		{
 			if (isname(arg, "blur"))
 			{
-				curr_time = time(NULL);
+				curr_time = get_time();
 				vict      = GET_OPPONENT(ch);
 				// 10 min timer.
 				if (obj->timer[0] + 600 <= curr_time)
@@ -439,7 +439,7 @@ int blur_shortsword(P_obj obj, P_char ch, int cmd, char *arg)
 		{
 			if (isname(arg, "misty"))
 			{
-				curr_time = time(NULL);
+				curr_time = get_time();
 				// 10 min timer.
 				if (obj->timer[0] + 600 <= curr_time)
 				{
@@ -486,7 +486,7 @@ int volo_longsword(P_obj obj, P_char ch, int cmd, char *arg)
 		{
 			if (isname(arg, "volo"))
 			{
-				curr_time = time(NULL);
+				curr_time = get_time();
 				vict      = ParseTarget(ch, arg);
 				// 10 min timer.
 				if (obj->timer[0] + 600 <= curr_time)
@@ -603,7 +603,7 @@ int snowogre_warhammer(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "fury"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 
 			// 10 min timer.
 			if (obj->timer[0] + 600 <= curr_time)
@@ -888,7 +888,7 @@ int deathseeker_mace(P_obj obj, P_char ch, int cmd, char *arg)
 		{
 			if (isname(arg, "death"))
 			{
-				curr_time = time(NULL);
+				curr_time = get_time();
 
 				if (obj->timer[0] + 600 <= curr_time)
 				{
@@ -951,7 +951,7 @@ int deathseeker_mace(P_obj obj, P_char ch, int cmd, char *arg)
 				target = get_char_vis(ch, viewperson);
 				if (target && target != ch && IS_PC(target) && !IS_TRUSTED(target))
 				{
-					curr_time = time(NULL);
+					curr_time = get_time();
 					if (obj->timer[0] + 600 <= curr_time)
 					{
 						switch (number(0, 1))
@@ -1131,7 +1131,7 @@ int illithid_axe(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (*Command && (cmd == CMD_SAY))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 			if (!strcmp(Command, "warp") && *Toperson)
 			{
 				target = get_char_vis(ch, Toperson);
@@ -1264,7 +1264,7 @@ int dagger_ra(P_obj obj, P_char ch, int cmd, char *arg)
 
 	if (cmd == CMD_PERIODIC)
 	{
-		curr_time = time(NULL);
+		curr_time = get_time();
 		ch        = obj->loc.wearing;
 
 		if (!CHAR_IN_NO_MAGIC_ROOM(ch))
@@ -1290,7 +1290,7 @@ int dagger_ra(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "ra"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 			// 750 sec timer == 12 min 30 sec.
 			if (obj->timer[1] + 750 <= curr_time)
 			{
@@ -1758,7 +1758,7 @@ int demon_slayer(P_obj obj, P_char ch, int cmd, char *arg)
 	// a bug, so just keep that in mind if you are looking to edit this.
 	if (obj->timer[1] == 0)
 	{
-		obj->timer[1] = time(NULL);
+		obj->timer[1] = get_time();
 	}
 	if (arg && (cmd == CMD_REMOVE))
 	{
@@ -1775,7 +1775,7 @@ int demon_slayer(P_obj obj, P_char ch, int cmd, char *arg)
 		{
 			if (isname(arg, "bel"))
 			{
-				curr_time = time(NULL);
+				curr_time = get_time();
 				vict      = ParseTarget(ch, arg);
 
 				// 800 sec timer == 13 min 20 sec, and 10 min timer.
@@ -1837,7 +1837,7 @@ int demon_slayer(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "euronymous"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 			vict      = ParseTarget(ch, arg);
 
 			// 450 sec == 7 min 30 sec & 10 min timer.
@@ -1919,7 +1919,7 @@ int demon_slayer(P_obj obj, P_char ch, int cmd, char *arg)
 		}
 		else if (isname(arg, "juiblex") || isname(arg, "jubilex"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 			vict      = ParseTarget(ch, arg);
 			// 450 sec == 7 min 30 sec & 10 min timers.
 			if (obj->timer[0] + 450 <= curr_time && obj->timer[1] + 600 <= curr_time)
@@ -2072,7 +2072,7 @@ int helmet_vampires(P_obj obj, P_char ch, int cmd, char *arg)
 		{
 			if (isname(arg, "dead"))
 			{
-				curr_time = time(NULL);
+				curr_time = get_time();
 				// 25 min timer.
 				if (obj->timer[0] + 1500 <= curr_time)
 				{
@@ -2131,7 +2131,7 @@ int helmet_vampires(P_obj obj, P_char ch, int cmd, char *arg)
 		{
 			if (isname(arg, "koztk"))
 			{
-				curr_time = time(NULL);
+				curr_time = get_time();
 				vict      = ParseTarget(ch, arg);
 				// 15 min timer.
 				if (obj->timer[0] + 900 <= curr_time)
@@ -2227,8 +2227,8 @@ int buckler_saints(P_obj obj, P_char ch, int cmd, char *arg)
 {
 	P_char            vict, target;
 	int               room, max_hp;
-	int               curr_time  = time(NULL);
-	int               curr_time2 = time(NULL);
+	int               curr_time  = get_time();
+	int               curr_time2 = get_time();
 	struct proc_data *data;
 
 	if (cmd == CMD_SET_PERIODIC)
@@ -2276,7 +2276,7 @@ int buckler_saints(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "gauce"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 			// 7 min 30 sec timer.
 			if (obj->timer[0] + 450 <= curr_time)
 			{
@@ -2295,7 +2295,7 @@ int buckler_saints(P_obj obj, P_char ch, int cmd, char *arg)
 		}
 		else if (isname(arg, "macavor"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 
 			if (obj->timer[0] + 450 <= curr_time)
 			{
@@ -2324,7 +2324,7 @@ int buckler_saints(P_obj obj, P_char ch, int cmd, char *arg)
 		}
 		else if (isname(arg, "verdonnaly"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 
 			if (obj->timer[0] + 450 <= curr_time)
 			{
@@ -2872,8 +2872,8 @@ int gauntlets_legend(P_obj obj, P_char ch, int cmd, char *arg)
 {
 	P_char            vict, target;
 	int               room;
-	int               curr_time  = time(NULL);
-	int               curr_time2 = time(NULL);
+	int               curr_time  = get_time();
+	int               curr_time2 = get_time();
 	struct proc_data *data;
 
 	if (cmd == CMD_SET_PERIODIC)
@@ -2965,7 +2965,7 @@ int gauntlets_legend(P_obj obj, P_char ch, int cmd, char *arg)
 		{
 			if (isname(arg, "hands"))
 			{
-				curr_time = time(NULL);
+				curr_time = get_time();
 				// 10 min timer.
 				if (obj->timer[0] + 600 <= curr_time)
 				{
@@ -3012,7 +3012,7 @@ int boots_abyss(P_obj obj, P_char ch, int cmd, char *arg)
     {
       if (isname(arg, "poseidon"))
       {
-        curr_time = time(NULL);
+        curr_time = get_time();
 
         if (obj->timer[0] + 1200 <= curr_time)
         {
@@ -3038,7 +3038,7 @@ int boots_abyss(P_obj obj, P_char ch, int cmd, char *arg)
     {
       if (isname(arg, "boots") || isname(arg, "abyss"))
       {
-        curr_time2 = time(NULL);
+        curr_time2 = get_time();
 
         if (obj->timer[1] + 600 <= curr_time2)
         {
@@ -3061,7 +3061,7 @@ int boots_abyss(P_obj obj, P_char ch, int cmd, char *arg)
   {
     if (isname(arg, "ground"))
     {
-      curr_time = time(NULL);
+      curr_time = get_time();
 
       if (obj->timer[0] + 600 <= curr_time)
       {
@@ -3083,7 +3083,7 @@ int boots_abyss(P_obj obj, P_char ch, int cmd, char *arg)
   {
     if (isname(arg, "water"))
     {
-      curr_time2 = time(NULL);
+      curr_time2 = get_time();
 
       if (obj->timer[1] + 600 <= curr_time2)
       {
@@ -3106,7 +3106,7 @@ int boots_abyss(P_obj obj, P_char ch, int cmd, char *arg)
   {
     if (isname(arg, "air"))
     {
-      curr_time2 = time(NULL);
+      curr_time2 = get_time();
 
       if (obj->timer[1] + 600 <= curr_time2)
       {
@@ -3242,7 +3242,7 @@ int poseidon_trident(P_obj obj, P_char ch, int cmd, char *arg)
   {
     if (isname(arg, "kraken"))
     {
-      curr_time = time(NULL);
+      curr_time = get_time();
 
       if (obj->timer[0] + 600 <= curr_time)
       {
@@ -3275,7 +3275,7 @@ int poseidon_trident(P_obj obj, P_char ch, int cmd, char *arg)
   {
     if (isname(arg, "poseidon"))
     {
-      curr_time = time(NULL);
+      curr_time = get_time();
 
       if (obj->timer[0] + 600 <= curr_time)
       {
@@ -3298,8 +3298,8 @@ int platemail_fame(P_obj obj, P_char ch, int cmd, char *arg)
 {
   P_char vict, target;
   int room, fame = 0;
-  int curr_time = time(NULL);
-  int curr_time2 = time(NULL);
+  int curr_time = get_time();
+  int curr_time2 = get_time();
   struct proc_data *data;
   struct affected_type *af;
 
@@ -3330,7 +3330,7 @@ int platemail_fame(P_obj obj, P_char ch, int cmd, char *arg)
   {
     if (isname(arg, "platemail")  || isname(arg, "fame"))
     {
-      curr_time = time(NULL);
+      curr_time = get_time();
 
       if (obj->timer[0] + 600 <= curr_time)
       {
@@ -3559,7 +3559,7 @@ int earring_powers(P_obj obj, P_char ch, int cmd, char *arg)
 		return FALSE;
 	}
 
-	curr_time = time(NULL);
+	curr_time = get_time();
 	// 10 min timer.
 	if (obj->timer[0] + 600 <= curr_time)
 	{
@@ -3952,7 +3952,7 @@ int collar_frost(P_obj obj, P_char ch, int cmd, char *arg)
 				return FALSE;
 			}
 
-			curr_time = time(NULL);
+			curr_time = get_time();
 			// 10 min timer.
 			if (obj->timer[0] + 600 <= curr_time)
 			{
@@ -4088,7 +4088,7 @@ int collar_flames(P_obj obj, P_char ch, int cmd, char *arg)
 				send_to_char("You have too many followers already.\n\r", ch);
 				return FALSE;
 			}
-			curr_time = time(NULL);
+			curr_time = get_time();
 			// 10 min timer.
 			if (obj->timer[0] + 600 <= curr_time)
 			{

--- a/src/specs.zion.c
+++ b/src/specs.zion.c
@@ -286,7 +286,7 @@ int zion_fnf(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "fire"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 			// 1 min timer.
 			if (obj->timer[0] + 60 <= curr_time)
 			{
@@ -303,7 +303,7 @@ int zion_fnf(P_obj obj, P_char ch, int cmd, char *arg)
 		}
 		else if (isname(arg, "flame"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 			// 3 min 20 sec timer.
 			if (obj->timer[1] + 200 <= curr_time)
 			{
@@ -421,7 +421,7 @@ int zion_light_dark(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "light") && GET_RACEWAR(ch) != RACEWAR_EVIL)
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 
 			if (obj->timer[0] + 60 <= curr_time)
 			{
@@ -443,7 +443,7 @@ int zion_light_dark(P_obj obj, P_char ch, int cmd, char *arg)
 		}
 		else if (isname(arg, "darkness") && GET_RACEWAR(ch) != RACEWAR_GOOD)
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 
 			if (obj->timer[0] + 60 <= curr_time)
 			{
@@ -771,7 +771,7 @@ int zion_netheril(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "blink"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 			// 15-20 sec timer ?
 			if (obj->timer[1] + number(15, 20) <= curr_time)
 			{
@@ -786,7 +786,7 @@ int zion_netheril(P_obj obj, P_char ch, int cmd, char *arg)
 		}
 		else if (isname(arg, "deflect"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 			// 500 sec timer == 8 min 20 sec.
 			if (obj->timer[2] + 500 <= curr_time)
 			{
@@ -898,7 +898,7 @@ int zion_mace_of_earth(P_obj obj, P_char ch, int cmd, char *arg)
 	{
 		if (isname(arg, "earth"))
 		{
-			curr_time = time(NULL);
+			curr_time = get_time();
 			// 1 min timer.
 			if (curr_time >= obj->timer[0] + 60)
 			{

--- a/src/spells.c
+++ b/src/spells.c
@@ -266,7 +266,7 @@ void cast_channel(int level, P_char ch, char *arg, int type, P_char tar_ch, P_ob
 	P_char t_ch, is_head = get_linked_char(ch, LNK_CONSENT);
 	P_obj  t_obj;
 	int    num_valid_chars = 0, obj_found = FALSE, obj_num;
-	int    curr_time = time(NULL);
+	int    curr_time = get_time();
 
 	switch (type)
 	{

--- a/src/sql.c
+++ b/src/sql.c
@@ -749,7 +749,7 @@ void sql_check_level_cap(long max_frags, int racewar)
 		return;
 	}
 	// If enough time has passed, and level should change, update level if appropriate.
-	if (next_update <= time(NULL))
+	if (next_update <= get_time())
 	{
 		// Have enough frags to update level.
 		if (old_level < frag_cap_config_cap_level_from_frags(max_frags / 100.))
@@ -776,7 +776,7 @@ void sql_check_level_cap(long max_frags, int racewar)
 			         max_frags / 100.,
 			         racewar,
 			         next_level,
-			         (long)(time(NULL) + SECS_PER_REAL_DAY * frag_cap_config_timer_days(old_level)));
+			         (long)(get_time() + SECS_PER_REAL_DAY * frag_cap_config_timer_days(old_level)));
 			db_query(query);
 		}
 		else if (max_frags > old_max_frags)

--- a/src/sql_player.c
+++ b/src/sql_player.c
@@ -279,7 +279,7 @@ static void sql_sync_account_character_cache(P_char ch, int room)
 		{
 			c->last_room = room;
 			c->level     = GET_LEVEL(ch);
-			c->last_save = time(NULL);
+			c->last_save = get_time();
 			break;
 		}
 		c = c->next;
@@ -957,7 +957,7 @@ bool sql_save_player_status(P_char ch, int type, int room)
 		                   room,
 		                   ch->player.time.birth,
 		                   ch->player.time.played,
-		                   (long)time(0),
+		                   (long)get_time(),
 		                   0, //!!! perm_aging
 		                   ch->base_stats.Str,
 		                   ch->base_stats.Dex,
@@ -1099,7 +1099,7 @@ bool sql_save_player_status(P_char ch, int type, int room)
 		                   room,
 		                   ch->player.time.birth,
 		                   ch->player.time.played,
-		                   (long)time(0),
+		                   (long)get_time(),
 		                   0, //!!! perm_aging
 		                   ch->base_stats.Str,
 		                   ch->base_stats.Dex,
@@ -3011,7 +3011,7 @@ bool sql_save_player_pets(P_char ch, int save_type)
 		         GET_MAX_VITALITY(pet),
 		         charm_duration,
 		         room_vnum,
-		         (long)time(0));
+		         (long)get_time());
 
 		if (!sql_run_query(ins_query))
 		{
@@ -3684,7 +3684,7 @@ bool sql_load_player_status(P_char ch, int pid)
 	ch->player.time.birth      = sql_row_long(row, col++, 0);
 	ch->player.time.played     = sql_row_int(row, col++, 0);
 	ch->player.time.saved      = sql_row_long(row, col++, 0);
-	ch->player.time.logon      = time(0);
+	ch->player.time.logon      = get_time();
 	col++; //!!! perm_aging
 
 	// base stats
@@ -7047,7 +7047,7 @@ bool sql_save_corpse(P_obj corpse)
 
 	int save_id = corpse->value[CORPSE_SAVEID];
 	if (save_id == 0)
-		save_id = time(NULL);
+		save_id = get_time();
 
 	int room_vnum = 0;
 	if (OBJ_ROOM(corpse) && corpse->loc.room > NOWHERE && corpse->loc.room <= top_of_world)
@@ -7798,7 +7798,7 @@ bool sql_save_shopkeeper(P_char ch, int shop_nr)
 
 	int  mob_vnum  = mob_index[GET_RNUM(ch)].virtual_number;
 	int  room_vnum = world[ch->in_room].number;
-	long save_time = time(0);
+	long save_time = get_time();
 
 	char del_query[128];
 	snprintf(del_query, sizeof(del_query), "DELETE FROM shopkeepers WHERE shop_id=%d", shop_nr);

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -58,7 +58,7 @@ void ssl_read_cert(void)
 	if (st.st_mtim.tv_sec == cert_time.tv_sec && st.st_mtim.tv_nsec == cert_time.tv_nsec)
 		return;
 
-	printf("[%ld] reading ssl cert: %s key: %s (old_mtime=%ld.%ld new_mtime=%ld.%ld)\n", time(NULL), certfile, keyfile, cert_time.tv_sec, cert_time.tv_nsec, st.st_mtim.tv_sec, st.st_mtim.tv_nsec);
+	printf("[%ld] reading ssl cert: %s key: %s (old_mtime=%ld.%ld new_mtime=%ld.%ld)\n", get_time(), certfile, keyfile, cert_time.tv_sec, cert_time.tv_nsec, st.st_mtim.tv_sec, st.st_mtim.tv_nsec);
 	cert_time = st.st_mtim;
 	if ((err = gnutls_certificate_allocate_credentials(&cred)) < 0 || (err = gnutls_certificate_set_x509_key_file(cred, certfile, keyfile, GNUTLS_X509_FMT_PEM)) < 0 ||
 	    (err = gnutls_certificate_set_known_dh_params(cred, GNUTLS_SEC_PARAM_MEDIUM)) < 0)

--- a/src/statistics.c
+++ b/src/statistics.c
@@ -57,7 +57,7 @@ void event_write_statistic(P_char ch, P_char victim, P_obj obj, void *data)
 	FILE      *f;
 	char      *buf = 0;
 
-	ct = time(0);
+	ct = get_time();
 	lt = localtime(&ct);
 	// tmstr = asctime(lt);
 	strftime(mdate, 10, "%Y%m%d", lt);
@@ -209,7 +209,7 @@ void do_statistic(P_char ch, char *argument, int val)
 	FILE                 *f;
 	int                   k = 0;
 
-	ct = time(0);
+	ct = get_time();
 	lt = localtime(&ct);
 	// tmstr = asctime(lt);
 	// create_zone(0);
@@ -500,7 +500,7 @@ int show_moth_stati(P_char ch, char *stati_date, char *argument)
 	FILE                 *f;
 	int                   k = 0;
 
-	ct = time(0);
+	ct = get_time();
 	lt = localtime(&ct);
 	// tmstr = asctime(lt);
 	// create_zone(0);

--- a/src/studioproc.c
+++ b/src/studioproc.c
@@ -820,7 +820,7 @@ static void sp_do_attack(struct sp_ctx *cx, struct sp_action *a, int aidx)
 	/* cooldown: a stamp in seconds, held per instance */
 	if (a->cooldown > 0)
 	{
-		now = (long)time(0);
+		now = (long)get_time();
 		if ((long)sp_state_get(cx, SP_TAG_COOLDOWN, aidx) > now)
 			return;
 		sp_state_set(cx, SP_TAG_COOLDOWN, aidx, (int)(now + a->cooldown));

--- a/src/timers.c
+++ b/src/timers.c
@@ -6,6 +6,8 @@
 #include "sql.h"
 #include "utility.h"
 
+extern time_t get_time();
+
 #ifdef __NO_MYSQL__
 void set_timer(const char *name) {}
 
@@ -13,7 +15,7 @@ void set_timer(const char *name, int date) {}
 
 int get_timer(const char *name) { return 0; }
 #else
-void set_timer(const char *name) { set_timer(name, time(NULL)); }
+void set_timer(const char *name) { set_timer(name, get_time()); }
 
 void set_timer(const char *name, int date)
 {
@@ -53,7 +55,7 @@ bool has_elapsed(const char *name, int seconds)
 {
 	int timer = get_timer(name);
 
-	if (time(NULL) > (timer + seconds))
+	if (get_time() > (timer + seconds))
 	{
 		return TRUE;
 	}

--- a/src/tradeskill.c
+++ b/src/tradeskill.c
@@ -601,7 +601,7 @@ void event_fish_check(P_char ch, P_char victim, P_obj, void *data)
 
 		gain_exp(ch, NULL, (GET_CHAR_SKILL(ch, SKILL_FISHING) * afp->modifier) / 100, EXP_BOON);
 
-		// fish->timer[0] = time(NULL); Fish no longer decay - drannak 5/13/13
+		// fish->timer[0] = get_time(); Fish no longer decay - drannak 5/13/13
 		obj_to_char(fish, ch);
 		return;
 	}

--- a/src/utility.c
+++ b/src/utility.c
@@ -700,7 +700,7 @@ void logit(const char *filename, const char *format, ...)
 	va_list args;
 
 	va_start(args, format);
-	ct = time(0);
+	ct = get_time();
 
 	bzero(tbuf, MAX_STRING_LENGTH);
 
@@ -980,7 +980,7 @@ static unsigned long long persistence_event_time_usec(void)
   struct timeval tv;
 
   if (gettimeofday(&tv, NULL))
-    return (unsigned long long)time(NULL) * 1000000ULL;
+    return (unsigned long long)get_time() * 1000000ULL;
 
   return ((unsigned long long)tv.tv_sec * 1000000ULL) +
          (unsigned long long)tv.tv_usec;
@@ -1351,7 +1351,7 @@ int persistence_quarantine_fallback_events(void)
   }
 
   snprintf(quarantine_path, sizeof(quarantine_path),
-           "%s.pwipe-quarantine.%ld.%ld", LOG_EVENT, (long)time(NULL),
+           "%s.pwipe-quarantine.%ld.%ld", LOG_EVENT, (long)get_time(),
            (long)getpid());
   if (rename(LOG_EVENT, quarantine_path))
   {
@@ -1484,7 +1484,7 @@ int persistence_replay_fallback_events(void)
   }
 
   snprintf(backup_path, sizeof(backup_path), "%s.persistence-replay.%ld.%ld",
-           LOG_EVENT, (long)time(NULL), (long)getpid());
+           LOG_EVENT, (long)get_time(), (long)getpid());
   if (link(LOG_EVENT, backup_path))
   {
     persistence_alert(AVATAR, "persistence_replay", "boot", "none",
@@ -2116,8 +2116,8 @@ struct time_info_data age(P_char ch)
 {
 	struct time_info_data player_age;
 
-	//  player_age = mud_time_passed(time (0), time(0));
-	player_age = mud_time_passed(time(0), ch->player.time.birth);
+	//  player_age = mud_time_passed(time (0), get_time());
+	player_age = mud_time_passed(get_time(), ch->player.time.birth);
 	/* natural
 	 * aging
 	 */
@@ -5091,7 +5091,7 @@ int is_introd(P_char viewee, P_char viewer)
 
 	if (viewer->only.pc->introd_list[mid] == nr)
 	{
-		viewer->only.pc->introd_times[mid] = time(0);
+		viewer->only.pc->introd_times[mid] = get_time();
 		return TRUE;
 	}
 #else
@@ -5140,7 +5140,7 @@ void add_intro(P_char introer, P_char introee)
 			introee->only.pc->introd_list[x - 1]  = introee->only.pc->introd_list[x];
 			introee->only.pc->introd_times[x - 1] = introee->only.pc->introd_times[x];
 			introee->only.pc->introd_list[x]      = GET_PID(introer);
-			introee->only.pc->introd_times[x]     = time(0);
+			introee->only.pc->introd_times[x]     = get_time();
 		}
 		else
 		{
@@ -5153,7 +5153,7 @@ void add_intro(P_char introer, P_char introee)
 	{ /* tack to end */
 		x--;
 		introee->only.pc->introd_list[x]  = GET_PID(introer);
-		introee->only.pc->introd_times[x] = time(0);
+		introee->only.pc->introd_times[x] = get_time();
 	}
 }
 
@@ -5163,7 +5163,7 @@ void purge_old_intros(P_char ch)
 	int temptime, tempnum;
 	int x, currtime;
 
-	currtime = time(0);
+	currtime = get_time();
 
 	for (x = 0; x < MAX_INTRO; x++)
 	{

--- a/src/wiz_newchar.c
+++ b/src/wiz_newchar.c
@@ -379,7 +379,7 @@ void do_newchar(P_char ch, char *argument, int cmd)
 		memset(c, 0, sizeof(struct acct_chars));
 		c->charname                            = str_dup(newch->player.name);
 		c->count                               = 1;
-		c->last                                = time(NULL);
+		c->last                                = get_time();
 		c->racewar                             = (GET_RACEWAR(newch) == RACEWAR_EVIL) ? ACCT_EVIL : ACCT_GOOD;
 		c->next                                = ch->desc->account->acct_character_list;
 		ch->desc->account->acct_character_list = c;

--- a/src/wizredis.c
+++ b/src/wizredis.c
@@ -19,7 +19,7 @@ static void format_time_ago(time_t ts, char *buf, size_t len)
 		return;
 	}
 
-	time_t now  = time(NULL);
+	time_t now  = get_time();
 	long   diff = now - ts;
 
 	if (diff < 0)

--- a/src/world_quest.c
+++ b/src/world_quest.c
@@ -766,7 +766,7 @@ bool createQuest(P_char ch, P_char giver)
 	ch->only.pc->quest_mob_vnum     = quest_mob;
 	ch->only.pc->quest_type         = QUEST_TYPE;
 	ch->only.pc->quest_accomplished = 0;
-	ch->only.pc->quest_started      = time(NULL);
+	ch->only.pc->quest_started      = get_time();
 	ch->only.pc->quest_zone_number  = zone_table[quest_zone].number;
 	ch->only.pc->quest_giver        = GET_VNUM(giver);
 	ch->only.pc->quest_level        = GET_LEVEL(ch);

--- a/src/ws_handlers.c
+++ b/src/ws_handlers.c
@@ -85,7 +85,7 @@ static int verify_durisweb_sig(const char *sig)
 	if (!secret)
 		return 0;
 
-	time_t now    = time(NULL);
+	time_t now    = time(0);
 	long   minute = now / 60;
 
 	/* check +/- 1 minute for clock skew */


### PR DESCRIPTION
Two new cmdline options:
 * `-R seed` for reproductible runs (but beware other sources of entropy)
 * `-F` for fast mode: no waiting between ticks

Also, disable old profiling by default — it causes over half of CPU use.

Arg parsing uses getopt now.