### PR TITLE
fix: harden event scheduling and async persistence

### DIFF
--- a/migrations/run_migration.sh
+++ b/migrations/run_migration.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-# Don't use set -e: the charset conversion functions can fail on legacy
-# tables (MyISAM, latin1, invalid datetime defaults) without affecting
-# the rest of the migration.  Individual run_sql calls track failures
-# and report them at the end.
-set +e
+# Migration is fail-closed: a failed step may leave a partially changed schema,
+# so continuing would make the remaining steps unsafe to reason about.
+set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
@@ -25,7 +23,7 @@ export MYSQL_PWD
 MYSQL=(mysql -h "$DB_HOST" -P "${DB_PORT:-3306}" -u "$DB_USER" "$DB_NAME")
 
 STEP=0
-TOTAL=112
+TOTAL=111
 FAILED=0
 
 run_sql() {
@@ -44,6 +42,7 @@ run_sql() {
         echo "FAILED"
         head -20 "$err_file"
         FAILED=$((FAILED + 1))
+        exit 1
     fi
     rm -f "$err_file"
     rm -f "$tmpfile"
@@ -63,6 +62,7 @@ run_sql_file() {
         echo "FAILED"
         head -20 "$err_file"
         FAILED=$((FAILED + 1))
+        exit 1
     fi
     rm -f "$err_file"
 }
@@ -83,6 +83,7 @@ run_check() {
         echo "FAILED"
         head -20 "$output_file"
         FAILED=$((FAILED + 1))
+        exit 1
     fi
     rm -f "$output_file"
 }
@@ -101,21 +102,21 @@ convert_tables_to_charset() {
     if ! db_charset=$("${MYSQL[@]}" -N -e "SELECT DEFAULT_CHARACTER_SET_NAME FROM information_schema.SCHEMATA WHERE SCHEMA_NAME=DATABASE();" 2>/dev/null); then
         echo "FAILED"
         FAILED=$((FAILED + 1))
-        return 1
+        exit 1
     fi
 
     if [ "$with_collation" = "1" ]; then
         if ! db_collation=$("${MYSQL[@]}" -N -e "SELECT DEFAULT_COLLATION_NAME FROM information_schema.SCHEMATA WHERE SCHEMA_NAME=DATABASE();" 2>/dev/null); then
             echo "FAILED"
             FAILED=$((FAILED + 1))
-            return 1
+            exit 1
         fi
     fi
 
     if ! tables=$("${MYSQL[@]}" -N -e "SELECT table_name FROM information_schema.tables WHERE table_schema=DATABASE() AND table_type='BASE TABLE';" 2>/dev/null); then
         echo "FAILED"
         FAILED=$((FAILED + 1))
-        return 1
+        exit 1
     fi
 
     if [ -n "$tables" ] && [ -n "$db_charset" ] && { [ "$with_collation" != "1" ] || [ -n "$db_collation" ]; }; then
@@ -152,7 +153,7 @@ EOF
 
     if [ "$table_failed" -ne 0 ]; then
         FAILED=$((FAILED + 1))
-        return 1
+        exit 1
     fi
 
     echo "ok"

--- a/src/Makefile
+++ b/src/Makefile
@@ -156,6 +156,7 @@ OBJS =  $(SHIP_OBJS) \
 				 objmisc.o \
 				 outposts.o \
 				 persistence_queue.o \
+				 latency_trace.o \
 				 sql_persistence_raw.o \
 				 sql_pool.o \
 				 plushit.o \

--- a/src/latency_trace.c
+++ b/src/latency_trace.c
@@ -1,0 +1,8 @@
+#include "latency_trace.h"
+
+latency_entry _latency_buf[LATENCY_TRACE_MAX_SAMPLES];
+int _latency_head = 0;
+int _latency_count = 0;
+pthread_mutex_t _latency_mutex = PTHREAD_MUTEX_INITIALIZER;
+_latency_section _latency_sections[_LATENCY_MAX_SECTIONS];
+int _latency_nsections = 0;

--- a/src/latency_trace.h
+++ b/src/latency_trace.h
@@ -38,10 +38,10 @@ typedef struct {
     long         tick;        /* game pulse when recorded */
 } latency_entry;
 
-static latency_entry _latency_buf[LATENCY_TRACE_MAX_SAMPLES];
-static int           _latency_head  = 0;
-static int           _latency_count = 0;
-static pthread_mutex_t _latency_mutex = PTHREAD_MUTEX_INITIALIZER;
+extern latency_entry _latency_buf[LATENCY_TRACE_MAX_SAMPLES];
+extern int           _latency_head;
+extern int           _latency_count;
+extern pthread_mutex_t _latency_mutex;
 
 /* per-section accumulators for summary */
 typedef struct {
@@ -53,8 +53,8 @@ typedef struct {
 } _latency_section;
 
 #define _LATENCY_MAX_SECTIONS 32
-static _latency_section _latency_sections[_LATENCY_MAX_SECTIONS];
-static int              _latency_nsections = 0;
+extern _latency_section _latency_sections[_LATENCY_MAX_SECTIONS];
+extern int              _latency_nsections;
 
 /* ======================== Internal helpers ======================== */
 

--- a/src/locker_async.c
+++ b/src/locker_async.c
@@ -982,6 +982,26 @@ static void drain_results(void)
 	}
 }
 
+static int locker_sync_fallback_durable(struct locker_async_slot *s, P_char chLocker)
+{
+	int owner_pid;
+	int owner_assoc;
+
+	if (!s || !chLocker)
+		return 0;
+
+	owner_pid = s->owner_pid;
+	owner_assoc = s->owner_assoc_id;
+	if (!owner_pid && !owner_assoc)
+		locker_owner_ids(chLocker, &owner_pid, &owner_assoc);
+
+	if (sql_save_locker(chLocker, owner_pid, owner_assoc))
+		return 1;
+	if (writeCharacter(chLocker, s->terminal ? 3 : 0, NOWHERE))
+		return 1;
+	return 0;
+}
+
 static int start_one_snapshot(struct locker_async_slot *s)
 {
 	struct locker_async_job job;
@@ -1026,20 +1046,31 @@ static int start_one_snapshot(struct locker_async_slot *s)
 	sql = build_locker_snapshot_sql(s);
 	if (!sql)
 	{
+		int durable_ok;
+
 		persistence_alert(AVATAR, "locker_async", s->locker_name, "none", "none",
 		                  "snapshot_failed",
-		                  "could not build snapshot; falling back to sync sql_save_locker");
+		                  "could not build snapshot; falling back to synchronous persistence");
+		durable_ok = locker_sync_fallback_durable(s, chLocker);
+		if (s->terminal && durable_ok)
 		{
-			int owner_pid = s->owner_pid, owner_assoc = s->owner_assoc_id;
-			if (!owner_pid && !owner_assoc)
-				locker_owner_ids(chLocker, &owner_pid, &owner_assoc);
-			if (!sql_save_locker(chLocker, owner_pid, owner_assoc))
-				writeCharacter(chLocker, s->terminal ? 3 : 0, NOWHERE);
-			if (s->terminal)
-			{
-				chLocker->specials.timer = 0;
-				extract_char(chLocker);
-			}
+			chLocker->specials.timer = 0;
+			extract_char(chLocker);
+			s->chLocker = NULL;
+			slot_clear(s);
+		}
+		else if (s->terminal)
+		{
+			persistence_alert(AVATAR, "locker_async", s->locker_name, "none", "none",
+			                  "terminal_not_durable",
+			                  "snapshot and synchronous fallbacks failed; refusing extract of locker char");
+			s->state = LCHK_DIRTY;
+			s->dirty_at = time(NULL);
+		}
+		else
+		{
+			if (chUser)
+				locker_async_restore_snapshot_view(chUser);
 			slot_clear(s);
 		}
 		return 0;
@@ -1054,20 +1085,32 @@ static int start_one_snapshot(struct locker_async_slot *s)
 
 	if (!job_push(&job))
 	{
+		int durable_ok;
+
 		free(sql);
 		persistence_alert(AVATAR, "locker_async", s->locker_name, "none", "none",
 		                  "job_queue_full",
-		                  "falling back to sync save");
+		                  "falling back to synchronous persistence");
+		durable_ok = locker_sync_fallback_durable(s, chLocker);
+		if (s->terminal && durable_ok)
 		{
-			int owner_pid = s->owner_pid, owner_assoc = s->owner_assoc_id;
-			if (!owner_pid && !owner_assoc)
-				locker_owner_ids(chLocker, &owner_pid, &owner_assoc);
-			sql_save_locker(chLocker, owner_pid, owner_assoc);
-			if (s->terminal)
-			{
-				chLocker->specials.timer = 0;
-				extract_char(chLocker);
-			}
+			chLocker->specials.timer = 0;
+			extract_char(chLocker);
+			s->chLocker = NULL;
+			slot_clear(s);
+		}
+		else if (s->terminal)
+		{
+			persistence_alert(AVATAR, "locker_async", s->locker_name, "none", "none",
+			                  "terminal_not_durable",
+			                  "job queue and synchronous fallbacks failed; refusing extract of locker char");
+			s->state = LCHK_DIRTY;
+			s->dirty_at = time(NULL);
+		}
+		else
+		{
+			if (chUser)
+				locker_async_restore_snapshot_view(chUser);
 			slot_clear(s);
 		}
 		return 0;

--- a/src/locker_async.c
+++ b/src/locker_async.c
@@ -1202,6 +1202,13 @@ void locker_async_init(void)
 	int err;
 	if (g_inited)
 		return;
+	if (!sql_pool_is_active())
+	{
+		logit(LOG_STATUS, "locker_async: connection pool unavailable; async worker disabled");
+		persistence_alert(AVATAR, "locker_async", "worker", "none", "none",
+		                  "pool_unavailable", "locker async worker disabled");
+		return;
+	}
 	memset(g_slots, 0, sizeof(g_slots));
 	memset(g_jobs, 0, sizeof(g_jobs));
 	memset(g_results, 0, sizeof(g_results));

--- a/src/new_events.c
+++ b/src/new_events.c
@@ -959,7 +959,7 @@ static long nevent_elapsed_us(const struct timespec *started, const struct times
 static long nevent_defer_suffix(P_nevent deferred_head)
 {
 	P_nevent event;
-	P_nevent deferred_tail;
+	P_nevent deferred_tail = NULL;
 	P_nevent future_head = NULL;
 	P_nevent prior;
 	int next_pulse;
@@ -1006,7 +1006,7 @@ static long nevent_defer_suffix(P_nevent deferred_head)
 	deferred_head->prev_sched = NULL;
 	deferred_tail->next_sched = NULL;
 
-	for (event = deferred_head;; event = event->next_sched)
+	for (event = deferred_head; event; event = event->next_sched)
 	{
 		event->element = next_pulse;
 		event->timer = 1;

--- a/src/persistence_queue.c
+++ b/src/persistence_queue.c
@@ -543,7 +543,7 @@ int persistence_item_event_worker_start(persistence_item_event_writer writer,
   return 1;
 }
 
-void persistence_item_event_worker_stop(int drain_remaining)
+int persistence_item_event_worker_stop(int drain_remaining)
 {
   int was_running;
   int stuck;
@@ -570,13 +570,14 @@ void persistence_item_event_worker_stop(int drain_remaining)
       logit("logs/log/debug",
             "PERSISTENCE: domain=item_event owner=worker action=stop_timeout detail=worker stop did not complete within %d sec; keeping stop gate set",
             PERSISTENCE_WORKER_STOP_JOIN_TIMEOUT_SECS);
-      return;
+      return 0;
     }
 
     pthread_mutex_lock(&persistence_item_event_queue_mutex);
     persistence_item_event_worker_stop_pending_flag = 0;
     pthread_mutex_unlock(&persistence_item_event_queue_mutex);
   }
+  return 1;
 }
 
 int persistence_item_event_worker_running(void)
@@ -1073,7 +1074,7 @@ int persistence_scalar_event_worker_start(persistence_scalar_event_writer writer
   return 1;
 }
 
-void persistence_scalar_event_worker_stop(int drain_remaining)
+int persistence_scalar_event_worker_stop(int drain_remaining)
 {
   int was_running;
   int stuck;
@@ -1100,13 +1101,14 @@ void persistence_scalar_event_worker_stop(int drain_remaining)
       logit("logs/log/debug",
             "PERSISTENCE: domain=scalar_event owner=worker action=stop_timeout detail=worker stop did not complete within %d sec; keeping stop gate set",
             PERSISTENCE_WORKER_STOP_JOIN_TIMEOUT_SECS);
-      return;
+      return 0;
     }
 
     pthread_mutex_lock(&persistence_scalar_event_queue_mutex);
     persistence_scalar_event_worker_stop_pending_flag = 0;
     pthread_mutex_unlock(&persistence_scalar_event_queue_mutex);
   }
+  return 1;
 }
 
 int persistence_scalar_event_worker_running(void)
@@ -1324,7 +1326,7 @@ int persistence_large_event_worker_start(persistence_scalar_event_writer writer,
   return 1;
 }
 
-void persistence_large_event_worker_stop(int drain_remaining)
+int persistence_large_event_worker_stop(int drain_remaining)
 {
   int was_running;
   int stuck;
@@ -1351,13 +1353,14 @@ void persistence_large_event_worker_stop(int drain_remaining)
       logit("logs/log/debug",
             "PERSISTENCE: domain=large_event owner=worker action=stop_timeout detail=worker stop did not complete within %d sec; keeping stop gate set",
             PERSISTENCE_WORKER_STOP_JOIN_TIMEOUT_SECS);
-      return;
+      return 0;
     }
 
     pthread_mutex_lock(&persistence_large_event_queue_mutex);
     persistence_large_event_worker_stop_pending_flag = 0;
     pthread_mutex_unlock(&persistence_large_event_queue_mutex);
   }
+  return 1;
 }
 
 int persistence_large_event_worker_running(void)

--- a/src/persistence_queue.c
+++ b/src/persistence_queue.c
@@ -58,6 +58,8 @@ static void persistence_worker_mysql_thread_end(void)
 struct persistence_event_queue_data
 {
   char **events;       /* dynamically allocated: events[i] = malloc(MAX_LEN) */
+  unsigned long long *generations; /* stable identity for each occupied slot */
+  unsigned long long next_generation;
   int slot_size;       /* bytes allocated for each events[i] slot */
   int head;
   int tail;
@@ -133,16 +135,26 @@ static int persistence_worker_timed_join(pthread_t thread)
 static int persistence_queue_alloc(persistence_event_queue_data *q, int capacity, int slot_size)
 {
   char **new_events = (char **)calloc(capacity, sizeof(char *));
+  unsigned long long *new_generations;
+
   if (!new_events) return 0;
+  new_generations = (unsigned long long *)calloc(capacity, sizeof(*new_generations));
+  if (!new_generations) {
+    free(new_events);
+    return 0;
+  }
   for (int i = 0; i < capacity; i++) {
     new_events[i] = (char *)malloc(slot_size);
     if (!new_events[i]) {
       for (int j = 0; j < i; j++) free(new_events[j]);
+      free(new_generations);
       free(new_events);
       return 0;
     }
   }
   q->events = new_events;
+  q->generations = new_generations;
+  q->next_generation = 1;
   q->slot_size = slot_size;
   q->capacity = capacity;
   return 1;
@@ -153,30 +165,41 @@ static int persistence_queue_alloc(persistence_event_queue_data *q, int capacity
 static int persistence_queue_grow(persistence_event_queue_data *q, int new_capacity)
 {
   char **new_events = (char **)calloc(new_capacity, sizeof(char *));
+  unsigned long long *new_generations;
+
   if (!new_events) return 0;
+  new_generations = (unsigned long long *)calloc(new_capacity, sizeof(*new_generations));
+  if (!new_generations) {
+    free(new_events);
+    return 0;
+  }
   for (int i = 0; i < new_capacity; i++) {
     new_events[i] = (char *)malloc(q->slot_size);
     if (!new_events[i]) {
       for (int j = 0; j < i; j++) free(new_events[j]);
+      free(new_generations);
       free(new_events);
       return 0;
     }
   }
 
-  /* Copy existing events preserving ring order */
+  /* Copy existing events preserving ring order and stable identity. */
   int old_count = q->count;
   for (int i = 0; i < old_count; i++) {
     int old_idx = (q->head + i) % q->capacity;
     memcpy(new_events[i], q->events[old_idx], q->slot_size);
+    new_generations[i] = q->generations[old_idx];
   }
 
   /* Free old storage */
   for (int i = 0; i < q->capacity; i++) free(q->events[i]);
   free(q->events);
+  free(q->generations);
 
   /* Swap in new */
   int old_capacity = q->capacity;
   q->events = new_events;
+  q->generations = new_generations;
   q->head = 0;
   q->tail = old_count;
   q->capacity = new_capacity;
@@ -203,6 +226,9 @@ static void persistence_queue_free(persistence_event_queue_data *q)
     free(q->events);
     q->events = NULL;
   }
+  free(q->generations);
+  q->generations = NULL;
+  q->next_generation = 1;
   q->head = 0;
   q->tail = 0;
   q->count = 0;
@@ -228,6 +254,15 @@ static int persistence_queue_line_too_long(const persistence_event_queue_data *q
     return 1;
 
   return (int)strlen(line) >= q->slot_size;
+}
+
+static unsigned long long persistence_queue_next_generation(persistence_event_queue_data *q)
+{
+  unsigned long long generation = q->next_generation++;
+
+  if (generation == 0)
+    generation = q->next_generation++;
+  return generation;
 }
 
 static void persistence_item_event_queue_pop_head(void)
@@ -300,6 +335,7 @@ int persistence_item_event_queue_enqueue(const char *line)
   else
   {
     snprintf(q->events[q->tail], q->slot_size, "%s", line);
+    q->generations[q->tail] = persistence_queue_next_generation(q);
     q->tail = (q->tail + 1) % q->capacity;
     q->count++;
     pthread_cond_signal(&persistence_item_event_queue_cond);
@@ -371,6 +407,7 @@ void persistence_item_event_queue_reset(void)
 static void *persistence_item_event_worker_main(void *unused)
 {
   char line[PERSISTENCE_EVENT_MAX_LEN];
+  unsigned long long persistence_item_event_worker_generation = 0;
   int should_write;
   int write_ok;
 
@@ -417,6 +454,8 @@ static void *persistence_item_event_worker_main(void *unused)
     {
       snprintf(line, sizeof(line), "%s",
                persistence_item_event_queue.events[persistence_item_event_queue.head]);
+      persistence_item_event_worker_generation =
+          persistence_item_event_queue.generations[persistence_item_event_queue.head];
       should_write = 1;
     }
     pthread_mutex_unlock(&persistence_item_event_queue_mutex);
@@ -437,9 +476,9 @@ static void *persistence_item_event_worker_main(void *unused)
     if (write_ok)
     {
       if (persistence_item_event_queue.count > 0 &&
-          !strncmp(line,
-                   persistence_item_event_queue.events[persistence_item_event_queue.head],
-                   PERSISTENCE_EVENT_MAX_LEN))
+          persistence_item_event_queue.generations[
+              persistence_item_event_queue.head] ==
+              persistence_item_event_worker_generation)
       {
         persistence_item_event_queue_pop_head();
       }
@@ -711,6 +750,7 @@ int persistence_scalar_event_queue_enqueue(const char *line)
   else
   {
     snprintf(q->events[q->tail], q->slot_size, "%s", line);
+    q->generations[q->tail] = persistence_queue_next_generation(q);
     q->tail = (q->tail + 1) % q->capacity;
     q->count++;
     pthread_cond_signal(&persistence_scalar_event_queue_cond);
@@ -804,6 +844,7 @@ int persistence_large_event_queue_enqueue(const char *line)
   else
   {
     snprintf(q->events[q->tail], q->slot_size, "%s", line);
+    q->generations[q->tail] = persistence_queue_next_generation(q);
     q->tail = (q->tail + 1) % q->capacity;
     q->count++;
     pthread_cond_signal(&persistence_large_event_queue_cond);
@@ -902,6 +943,7 @@ void persistence_scalar_event_queue_reset(void)
 static void *persistence_scalar_event_worker_main(void *unused)
 {
   char line[PERSISTENCE_EVENT_MAX_LEN];
+  unsigned long long persistence_scalar_event_worker_generation = 0;
   int should_write;
   int write_ok;
 
@@ -942,6 +984,8 @@ static void *persistence_scalar_event_worker_main(void *unused)
     {
       snprintf(line, sizeof(line), "%s",
                persistence_scalar_event_queue.events[persistence_scalar_event_queue.head]);
+      persistence_scalar_event_worker_generation =
+          persistence_scalar_event_queue.generations[persistence_scalar_event_queue.head];
       should_write = 1;
     }
     pthread_mutex_unlock(&persistence_scalar_event_queue_mutex);
@@ -962,9 +1006,9 @@ static void *persistence_scalar_event_worker_main(void *unused)
     if (write_ok)
     {
       if (persistence_scalar_event_queue.count > 0 &&
-          !strncmp(line,
-                   persistence_scalar_event_queue.events[persistence_scalar_event_queue.head],
-                   PERSISTENCE_EVENT_MAX_LEN))
+          persistence_scalar_event_queue.generations[
+              persistence_scalar_event_queue.head] ==
+              persistence_scalar_event_worker_generation)
       {
         persistence_scalar_event_queue_pop_head();
       }
@@ -1150,6 +1194,7 @@ unsigned long persistence_scalar_event_worker_write_failures(void)
 static void *persistence_large_event_worker_main(void *unused)
 {
   char line[PERSISTENCE_LARGE_EVENT_MAX_LEN];
+  unsigned long long persistence_large_event_worker_generation = 0;
   int should_write;
   int write_ok;
 
@@ -1190,6 +1235,8 @@ static void *persistence_large_event_worker_main(void *unused)
     {
       snprintf(line, sizeof(line), "%s",
                persistence_large_event_queue.events[persistence_large_event_queue.head]);
+      persistence_large_event_worker_generation =
+          persistence_large_event_queue.generations[persistence_large_event_queue.head];
       should_write = 1;
     }
     pthread_mutex_unlock(&persistence_large_event_queue_mutex);
@@ -1210,9 +1257,9 @@ static void *persistence_large_event_worker_main(void *unused)
     if (write_ok)
     {
       if (persistence_large_event_queue.count > 0 &&
-          !strncmp(line,
-                   persistence_large_event_queue.events[persistence_large_event_queue.head],
-                   PERSISTENCE_LARGE_EVENT_MAX_LEN))
+          persistence_large_event_queue.generations[
+              persistence_large_event_queue.head] ==
+              persistence_large_event_worker_generation)
       {
         persistence_large_event_queue_pop_head();
       }

--- a/src/persistence_queue.h
+++ b/src/persistence_queue.h
@@ -32,7 +32,7 @@ void persistence_item_event_queue_reset(void);
 
 int persistence_item_event_worker_start(persistence_item_event_writer writer,
                                         void *context);
-void persistence_item_event_worker_stop(int drain_remaining);
+int persistence_item_event_worker_stop(int drain_remaining);
 int persistence_item_event_worker_running(void);
 int persistence_item_event_worker_stop_pending(void);
 unsigned long persistence_item_event_worker_written(void);
@@ -47,7 +47,7 @@ void persistence_scalar_event_queue_reset(void);
 
 int persistence_scalar_event_worker_start(persistence_scalar_event_writer writer,
                                           void *context);
-void persistence_scalar_event_worker_stop(int drain_remaining);
+int persistence_scalar_event_worker_stop(int drain_remaining);
 int persistence_scalar_event_worker_running(void);
 int persistence_scalar_event_worker_stop_pending(void);
 unsigned long persistence_scalar_event_worker_written(void);
@@ -63,7 +63,7 @@ void persistence_large_event_queue_reset(void);
 
 int persistence_large_event_worker_start(persistence_scalar_event_writer writer,
                                           void *context);
-void persistence_large_event_worker_stop(int drain_remaining);
+int persistence_large_event_worker_stop(int drain_remaining);
 int persistence_large_event_worker_running(void);
 int persistence_large_event_worker_stop_pending(void);
 unsigned long persistence_large_event_worker_written(void);

--- a/src/sql_pool.c
+++ b/src/sql_pool.c
@@ -354,9 +354,16 @@ MYSQL *sql_pool_replace_connection(MYSQL *conn)
 	return replacement;
 }
 
-/* ------------------------------------------------------------------ */
-/*  Stats                                                              */
-/* ------------------------------------------------------------------ */
+/* ---- Stats (debug / monitoring) ---- */
+
+int sql_pool_is_active(void)
+{
+	int active;
+	pthread_mutex_lock(&pool_mutex);
+	active = pool != NULL;
+	pthread_mutex_unlock(&pool_mutex);
+	return active;
+}
 
 int sql_pool_available(void)
 {
@@ -365,7 +372,7 @@ int sql_pool_available(void)
 	if (pool)
 	{
 		for (int i = 0; i < pool_size; i++)
-			if (!pool[i].in_use)
+			if (!pool[i].in_use && pool[i].conn)
 				avail++;
 	}
 	pthread_mutex_unlock(&pool_mutex);
@@ -430,8 +437,9 @@ MYSQL *sql_pool_replace_connection(MYSQL *conn)
 	return NULL;
 }
 
-int sql_pool_available(void) { return 0; }
-int sql_pool_in_use(void)    { return 0; }
-int sql_pool_total(void)     { return 0; }
+int sql_pool_is_active(void)    { return 0; }
+int sql_pool_available(void)   { return 0; }
+int sql_pool_in_use(void)      { return 0; }
+int sql_pool_total(void)       { return 0; }
 
 #endif /* __NO_MYSQL__ */

--- a/src/sql_pool.h
+++ b/src/sql_pool.h
@@ -60,7 +60,8 @@ MYSQL *sql_pool_replace_connection(MYSQL *conn);
 
 /* ---- Stats (debug / monitoring) ---- */
 
-int sql_pool_available(void);   /* how many connections are free */
+int sql_pool_is_active(void);    /* whether a usable pool was initialised */
+int sql_pool_available(void);
 int sql_pool_in_use(void);      /* how many are currently borrowed */
 int sql_pool_total(void);       /* total pool size (0 before init) */
 

--- a/src/storage_lockers.c
+++ b/src/storage_lockers.c
@@ -320,27 +320,25 @@ static void locker_eject_to_exit(P_char ch, int room)
 static bool locker_handle_leave(P_char ch, StorageLocker *pLocker, int room, int troom)
 {
 	P_char tmpChar = NULL;
+	P_char nextChar = NULL;
 
 	if (!ch || !pLocker || (ch != pLocker->GetLockerUser()))
 		return true;
 
-	// DEFERRED: infinite loop — iterates world[ch->in_room].people but the
-	// loop body compares against world[ch->in_room].people (the list head)
-	// instead of tmpChar, so it never advances when ch is the head. Pre-existing
-	// from master. Fix requires rewriting to iterate tmpChar->next_in_room.
+	/* Eject every other occupant while preserving the next pointer before
+	 * char_from_room()/char_to_room() mutate the current room list. */
 	tmpChar = world[ch->in_room].people;
 	while (tmpChar)
 	{
-		if (ch == world[ch->in_room].people)
+		nextChar = tmpChar->next_in_room;
+		if (tmpChar != ch)
 		{
-			tmpChar = ch->next_in_room;
-			continue;
+			/* this person isn't the proper occupant, so kick them the hell out */
+			send_to_char("You feel yourself being (ungracefully) ejected from the locker.\r\n", tmpChar);
+			char_from_room(tmpChar);
+			char_to_room(tmpChar, locker_exit_room(ch, room), 0);
 		}
-		/* this person isn't the proper occupant, so kick them the hell out */
-		send_to_char("You feel yourself being (ungracefully) ejected from the locker.\r\n", tmpChar);
-		char_from_room(tmpChar);
-		char_to_room(tmpChar, locker_exit_room(ch, room), 0);
-		tmpChar = world[ch->in_room].people;
+		tmpChar = nextChar;
 	} /* while */
 
 	/* Move items from room/chests to the locker character for saving. */

--- a/src/utility.c
+++ b/src/utility.c
@@ -854,6 +854,25 @@ const char *persistence_item_uid_text(P_obj obj, char *buf, int buf_size)
   return buf;
 }
 
+static const char *persistence_fallback_record_line(const char *line,
+                                                      const char *domain,
+                                                      char *buf,
+                                                      int buf_size)
+{
+  if (!line || !*line)
+    return NULL;
+
+  if (!domain || strcmp(domain, "scalar_event") != 0 ||
+      !strncmp(line, PERSISTENCE_SCALAR_EVENT_PREFIX,
+               strlen(PERSISTENCE_SCALAR_EVENT_PREFIX)))
+    return line;
+
+  if (!buf || buf_size <= 0 ||
+      snprintf(buf, buf_size, "%s%s", PERSISTENCE_SCALAR_EVENT_PREFIX, line) >= buf_size)
+    return NULL;
+  return buf;
+}
+
 int persistence_write_fallback_event_line(const char *line,
                                           const char *domain,
                                           const char *owner,
@@ -861,6 +880,8 @@ int persistence_write_fallback_event_line(const char *line,
 {
   FILE *log_f;
   int ok = 1;
+  char scalar_record[PERSISTENCE_EVENT_MAX_LEN + 64];
+  const char *record_line;
   static unsigned long fallback_count = 0;
 
   if (_pwipe)
@@ -876,6 +897,12 @@ int persistence_write_fallback_event_line(const char *line,
   }
 
   if (!line || !*line)
+    return 0;
+
+  record_line = persistence_fallback_record_line(line, domain,
+                                                   scalar_record,
+                                                   sizeof(scalar_record));
+  if (!record_line)
     return 0;
 
   pthread_mutex_lock(&persistence_fallback_log_mutex);
@@ -906,7 +933,7 @@ int persistence_write_fallback_event_line(const char *line,
   }
 
   clock_t _fb_beg = clock();
-  if (fputs(line, log_f) < 0 || fputs("\n", log_f) < 0)
+  if (fputs(record_line, log_f) < 0 || fputs("\n", log_f) < 0)
     ok = 0;
 
   if (fflush(log_f) || fsync(fileno(log_f)))
@@ -1002,8 +1029,8 @@ int persistence_flush_item_events(int max_events)
     return 0;
 
   pending = persistence_item_event_queue_pending();
-  if (max_events <= 0)
-    max_events = pending;
+  if (max_events <= 0 || max_events > PERSISTENCE_FLUSH_BATCH_MAX)
+    max_events = pending < PERSISTENCE_FLUSH_BATCH_MAX ? pending : PERSISTENCE_FLUSH_BATCH_MAX;
   if (pending > 0)
   {
     pthread_mutex_lock(&persistence_fallback_log_mutex);
@@ -1125,6 +1152,8 @@ int persistence_flush_item_events(int max_events)
 int persistence_flush_scalar_events(int max_events)
 {
   char line[PERSISTENCE_EVENT_MAX_LEN];
+  char fallback_line[PERSISTENCE_EVENT_MAX_LEN + 64];
+  const char *record_line;
   unsigned long dropped;
   FILE *log_f = NULL;
   int flushed = 0;
@@ -1135,8 +1164,8 @@ int persistence_flush_scalar_events(int max_events)
     return 0;
 
   pending = persistence_scalar_event_queue_pending();
-  if (max_events <= 0)
-    max_events = pending;
+  if (max_events <= 0 || max_events > PERSISTENCE_FLUSH_BATCH_MAX)
+    max_events = pending < PERSISTENCE_FLUSH_BATCH_MAX ? pending : PERSISTENCE_FLUSH_BATCH_MAX;
   if (pending > 0)
   {
     pthread_mutex_lock(&persistence_fallback_log_mutex);
@@ -1167,10 +1196,18 @@ int persistence_flush_scalar_events(int max_events)
   while (ok && flushed < max_events &&
          persistence_scalar_event_queue_dequeue(line, sizeof(line)))
   {
+    record_line = persistence_fallback_record_line(line, "scalar_event",
+                                                     fallback_line,
+                                                     sizeof(fallback_line));
+    if (!record_line)
+    {
+      ok = 0;
+      break;
+    }
     if (durability_offset < 0)
       durability_offset = ftell(log_f);
     long file_offset = ftell(log_f);
-    if (fputs(line, log_f) < 0 || fputs("\n", log_f) < 0)
+    if (fputs(record_line, log_f) < 0 || fputs("\n", log_f) < 0)
     {
       ok = 0;
       if (file_offset >= 0 && ftruncate(fileno(log_f), file_offset) == 0)
@@ -1432,8 +1469,9 @@ int persistence_replay_fallback_events(void)
     else if (persistence_line_has_prefix(event_line,
                                          PERSISTENCE_SCALAR_EVENT_PREFIX))
     {
+      const char *scalar_sql = event_line + strlen(PERSISTENCE_SCALAR_EVENT_PREFIX);
       saw_persistence = 1;
-      if (sql_persistence_write_scalar_event_line(event_line))
+      if (*scalar_sql && sql_persistence_write_scalar_event_line(scalar_sql))
         replayed++;
       else
       {
@@ -1657,9 +1695,30 @@ int persistence_prepare_pwipe(void)
 void persistence_stop_scalar_event_worker(void)
 {
   unsigned long failures;
+  int stop_ok;
 
-  persistence_scalar_event_worker_stop(0);
-  persistence_flush_scalar_events(0);
+  stop_ok = persistence_scalar_event_worker_stop(0);
+  if (!stop_ok)
+  {
+    persistence_alert(AVATAR, "scalar_event", "worker", "none", "none",
+                      "stop_incomplete",
+                      "worker join timed out; refusing concurrent fallback drain");
+    return;
+  }
+
+  while (persistence_scalar_event_queue_pending() > 0)
+  {
+    int before = persistence_scalar_event_queue_pending();
+    int flushed = persistence_flush_scalar_events(PERSISTENCE_FLUSH_BATCH_MAX);
+    if (flushed <= 0 || persistence_scalar_event_queue_pending() >= before)
+      break;
+  }
+
+  if (persistence_scalar_event_queue_pending() > 0)
+    persistence_alert(AVATAR, "scalar_event", "queue", "none", "none",
+                      "flush_incomplete",
+                      "%d scalar events remain queued after worker stop",
+                      persistence_scalar_event_queue_pending());
 
   failures = persistence_scalar_event_worker_write_failures();
   if (failures)
@@ -1691,9 +1750,30 @@ unsigned long persistence_dropped_scalar_events(void)
 void persistence_stop_item_event_worker(void)
 {
   unsigned long failures;
+  int stop_ok;
 
-  persistence_item_event_worker_stop(0);
-  persistence_flush_item_events(0);
+  stop_ok = persistence_item_event_worker_stop(0);
+  if (!stop_ok)
+  {
+    persistence_alert(AVATAR, "item_event", "worker", "none", "none",
+                      "stop_incomplete",
+                      "worker join timed out; refusing concurrent fallback drain");
+    return;
+  }
+
+  while (persistence_item_event_queue_pending() > 0)
+  {
+    int before = persistence_item_event_queue_pending();
+    int flushed = persistence_flush_item_events(PERSISTENCE_FLUSH_BATCH_MAX);
+    if (flushed <= 0 || persistence_item_event_queue_pending() >= before)
+      break;
+  }
+
+  if (persistence_item_event_queue_pending() > 0)
+    persistence_alert(AVATAR, "item_event", "queue", "none", "none",
+                      "flush_incomplete",
+                      "%d item events remain queued after worker stop",
+                      persistence_item_event_queue_pending());
 
   failures = persistence_item_event_worker_write_failures();
   if (failures)

--- a/src/utility.c
+++ b/src/utility.c
@@ -46,6 +46,7 @@ using namespace std;
 #include "specializations.h"
 #include "spells.h"
 #include "sql.h"
+#include "sql_pool.h"
 #include "sql_player.h"
 #include "weather.h"
 
@@ -1607,6 +1608,12 @@ void utility_latency_reset(void)
 
 int persistence_start_item_event_worker(void)
 {
+  if (!sql_pool_is_active())
+  {
+    persistence_alert(AVATAR, "item_event", "worker", "none", "none",
+                      "pool_unavailable", "item worker disabled; using durable flat-log fallback");
+    return 0;
+  }
   if (!persistence_item_event_worker_start(persistence_item_event_log_writer,
                                            NULL))
   {
@@ -1652,6 +1659,12 @@ static int persistence_scalar_event_log_writer(const char *line, void *context)
 
 int persistence_start_scalar_event_worker(void)
 {
+  if (!sql_pool_is_active())
+  {
+    persistence_alert(AVATAR, "scalar_event", "worker", "none", "none",
+                      "pool_unavailable", "scalar worker disabled; using sync fallback");
+    return 0;
+  }
   if (!persistence_scalar_event_worker_start(persistence_scalar_event_log_writer,
                                              NULL))
   {
@@ -1842,12 +1855,14 @@ void persistence_record_item_event(const char *event_type, P_obj obj,
            persistence_clean_field(target, target_buf, sizeof(target_buf)),
            persistence_clean_field(note, note_buf, sizeof(note_buf)));
 
-  if (!persistence_item_event_queue_enqueue(line))
+  if (!persistence_item_event_worker_running() ||
+      !persistence_item_event_queue_enqueue(line))
   {
-    persistence_write_fallback_event_line(line,
-                                          "item_event",
-                                          actor ? J_NAME(actor) : "system",
-                                          "queue_full_flat_fallback");
+    persistence_write_fallback_event_line(
+        line, "item_event", actor ? J_NAME(actor) : "system",
+        persistence_item_event_worker_running()
+            ? "queue_full_flat_fallback"
+            : "worker_unavailable_flat_fallback");
   }
 
   persistence_worker_heartbeat_check(0);

--- a/tests/async/test_fallback_flush_batching.py
+++ b/tests/async/test_fallback_flush_batching.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""Fallback flushes must retain bounded recovery batches and drain in chunks."""
+from pathlib import Path
+import re
+
+source = (Path(__file__).resolve().parents[2] / "src/utility.c").read_text()
+compact = re.sub(r"\s+", " ", source)
+
+for domain in ("item", "scalar"):
+    start = source.index(f"int persistence_flush_{domain}_events")
+    end = source.index("\n}\n", start) + 3
+    body = source[start:end]
+    assert "PERSISTENCE_FLUSH_BATCH_MAX" in body, domain
+    assert "max_events > PERSISTENCE_FLUSH_BATCH_MAX" in body, domain
+
+assert "while (persistence_scalar_event_queue_pending() > 0)" in source
+assert "while (persistence_item_event_queue_pending() > 0)" in source
+assert "persistence_flush_scalar_events(PERSISTENCE_FLUSH_BATCH_MAX)" in compact
+assert "persistence_flush_item_events(PERSISTENCE_FLUSH_BATCH_MAX)" in compact
+
+print("bounded fallback flush checks passed")

--- a/tests/async/test_latency_trace_global_state.py
+++ b/tests/async/test_latency_trace_global_state.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Latency state must be process-global when the header is included widely."""
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[2]
+header = (root / "src/latency_trace.h").read_text()
+makefile = (root / "src/Makefile").read_text()
+impl = (root / "src/latency_trace.c").read_text()
+
+assert "extern latency_entry _latency_buf" in header
+assert "extern pthread_mutex_t _latency_mutex" in header
+assert "extern _latency_section _latency_sections" in header
+assert "latency_entry _latency_buf" in impl
+assert "pthread_mutex_t _latency_mutex" in impl
+assert "latency_trace.o" in makefile
+
+print("process-global latency trace checks passed")

--- a/tests/async/test_locker_terminal_fallback_contract.py
+++ b/tests/async/test_locker_terminal_fallback_contract.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Fail-closed contracts for every terminal locker sync fallback path."""
+from pathlib import Path
+
+source = (Path(__file__).resolve().parents[2] / "src/locker_async.c").read_text()
+
+helper_start = source.index("static int locker_sync_fallback_durable")
+helper_end = source.index("\n}\n", helper_start) + 3
+helper = source[helper_start:helper_end]
+assert "sql_save_locker" in helper
+assert "writeCharacter" in helper
+assert helper.index("sql_save_locker") < helper.index("writeCharacter")
+assert "return 1;" in helper
+assert "return 0;" in helper
+
+start = source.index("static int start_one_snapshot")
+end = source.index("\n}\n", start) + 3
+body = source[start:end]
+
+# Snapshot-build failure and job-queue-full must share the same durability gate.
+assert body.count("locker_sync_fallback_durable(s, chLocker)") == 2
+assert body.count("if (s->terminal && durable_ok)") == 2
+assert body.count('"terminal_not_durable"') == 2
+assert body.count("s->state = LCHK_DIRTY;") >= 2
+
+# Neither failure branch may discard the recovery fence unconditionally.
+snapshot_failed = body[body.index("if (!sql)"):body.index("if (!job_push")]
+job_full = body[body.index("if (!job_push"):]
+for label, branch in (("snapshot_failed", snapshot_failed), ("job_queue_full", job_full)):
+    assert "if (s->terminal && durable_ok)" in branch, label
+    assert "else if (s->terminal)" in branch, label
+    assert branch.index("if (s->terminal && durable_ok)") < branch.index("extract_char(chLocker)"), label
+
+print("locker terminal fallback fail-closed checks passed")

--- a/tests/async/test_nevent_budget_contract.py
+++ b/tests/async/test_nevent_budget_contract.py
@@ -6,6 +6,8 @@ src = (ROOT / "src" / "new_events.c").read_text()
 assert 'DURIS_NEVENT_BUDGET_USEC' in src
 assert 'DURIS_NEVENT_MAX_CALLBACKS' in src
 assert 'nevent_defer_suffix' in src
+assert 'P_nevent deferred_tail = NULL;' in src
+assert 'for (event = deferred_head; event; event = event->next_sched)' in src
 assert 'deferred_head->prev_sched = NULL' in src
 assert 'event->element = next_pulse' in src
 assert 'event->timer > 1' in src

--- a/tests/async/test_persistence.c
+++ b/tests/async/test_persistence.c
@@ -40,6 +40,26 @@ static int capture_writer(const char *line, void *context)
 	return 1;
 }
 
+struct identity_race_state
+{
+	int calls = 0;
+};
+
+static int identity_race_writer(const char *line, void *context)
+{
+	auto *state = static_cast<identity_race_state *>(context);
+	state->calls++;
+	if (state->calls == 1)
+	{
+		char removed[PERSISTENCE_EVENT_MAX_LEN];
+		if (!persistence_scalar_event_queue_dequeue(removed, sizeof(removed)))
+			return 0;
+		if (!persistence_scalar_event_queue_enqueue(line))
+			return 0;
+	}
+	return 1;
+}
+
 static bool wait_for_scalar_queue_empty(int timeout_ms)
 {
 	for (int i = 0; i < timeout_ms; ++i)
@@ -417,6 +437,35 @@ static bool test_queue_rejects_oversize_item_impl()
 	       expect(persistence_large_event_queue_dropped() == 0, "oversize item payload should not be dropped from large queue");
 }
 
+static bool test_worker_generation_identity_impl()
+{
+	persistence_scalar_event_worker_stop(0);
+	persistence_scalar_event_queue_reset();
+
+	identity_race_state state;
+	if (!expect(persistence_scalar_event_worker_start(identity_race_writer, &state),
+	            "failed to start scalar worker for generation identity test"))
+		return false;
+	if (!expect(persistence_scalar_event_queue_enqueue("identical-event"),
+	            "failed to enqueue generation identity event"))
+	{
+		persistence_scalar_event_worker_stop(0);
+		return false;
+	}
+	if (!expect(wait_for_scalar_queue_empty(8000),
+	            "generation identity queue did not drain"))
+	{
+		persistence_scalar_event_worker_stop(0);
+		return false;
+	}
+	persistence_scalar_event_worker_stop(1);
+
+	return expect(state.calls == 2,
+	              "replacement event with identical text must be written separately") &&
+	       expect(persistence_scalar_event_queue_pending() == 0,
+	              "generation identity test should leave no queued events");
+}
+
 static bool test_worker_large_roundtrip_impl()
 {
 	persistence_large_event_worker_stop(0);
@@ -462,6 +511,7 @@ static const suite_case kCases[] =
 	{"queue_routes_oversize_item_to_large", test_queue_rejects_oversize_item_impl},
 	{"worker_scalar_fallback", test_worker_scalar_fallback_impl},
 	{"worker_scalar_fifo_after_retry", test_worker_scalar_fifo_after_retry_impl},
+	{"worker_generation_identity", test_worker_generation_identity_impl},
 	{"worker_scalar_stale_heartbeat_shutdown_fallback", test_worker_scalar_stale_heartbeat_shutdown_fallback_impl},
 	{"worker_item_fifo", test_worker_item_fifo_impl},
 	{"worker_large_roundtrip", test_worker_large_roundtrip_impl},

--- a/tests/async/test_persistence_queue_generation_identity.py
+++ b/tests/async/test_persistence_queue_generation_identity.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Queue completion must use per-slot identity, never serialized text."""
+from pathlib import Path
+import re
+
+source = (Path(__file__).resolve().parents[2] / "src/persistence_queue.c").read_text()
+compact = re.sub(r"\s+", " ", source)
+
+assert "unsigned long long *generations;" in source
+assert "unsigned long long next_generation;" in source
+assert "q->generations[q->tail] = persistence_queue_next_generation(q);" in source
+assert "new_generations[i] = q->generations[old_idx];" in source
+assert "free(q->generations);" in source
+
+# Every worker snapshots and validates the exact queue generation it wrote.
+for domain in ("item", "scalar", "large"):
+    assert f"persistence_{domain}_event_worker_generation" in source, domain
+    assert (
+        f"persistence_{domain}_event_queue.generations[ "
+        f"persistence_{domain}_event_queue.head] == "
+        f"persistence_{domain}_event_worker_generation"
+    ) in compact, domain
+
+assert "strncmp(line," not in source
+print("persistence queue generation identity checks passed")

--- a/tests/async/test_room_leave_veto_contract.py
+++ b/tests/async/test_room_leave_veto_contract.py
@@ -34,6 +34,15 @@ leave_start = lockers.index("if (cmd == CMD_FROMROOM)")
 leave = lockers[leave_start:leave_start + 220]
 assert "return ROOM_PROC_LEAVE_VETO;" in leave
 
+leave_handler_start = lockers.index("static bool locker_handle_leave")
+leave_handler_end = lockers.index("\n}\n", leave_handler_start) + 3
+leave_handler = lockers[leave_handler_start:leave_handler_end]
+assert "P_char nextChar = NULL;" in leave_handler
+assert "nextChar = tmpChar->next_in_room;" in leave_handler
+assert "if (tmpChar != ch)" in leave_handler
+assert "tmpChar = nextChar;" in leave_handler
+assert "tmpChar = world[ch->in_room].people;" not in leave_handler[leave_handler.index("tmpChar = world[ch->in_room].people;") + 1:]
+
 # The ordinary movement path must not insert after a vetoed/failed unlink.
 move_start = actmove.index("int do_simple_move_skipping_procs")
 move_end = actmove.index("int do_simple_move(", move_start)

--- a/tests/async/test_scalar_fallback_replay_framing.py
+++ b/tests/async/test_scalar_fallback_replay_framing.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Scalar fallback records must carry the replay discriminator."""
+from pathlib import Path
+import re
+
+root = Path(__file__).resolve().parents[2]
+utility = (root / "src/utility.c").read_text()
+compact = re.sub(r"\s+", " ", utility)
+
+assert "static const char *persistence_fallback_record_line" in utility
+assert "PERSISTENCE_SCALAR_EVENT_PREFIX" in utility
+assert "strcmp(domain, \"scalar_event\")" in utility
+assert "persistence_fallback_record_line(line, \"scalar_event\"" in compact
+assert "fputs(record_line, log_f)" in utility
+assert "const char *scalar_sql = event_line + strlen(PERSISTENCE_SCALAR_EVENT_PREFIX);" in utility
+assert "sql_persistence_write_scalar_event_line(scalar_sql)" in utility
+
+print("scalar fallback replay framing checks passed")

--- a/tests/async/test_sql_pool_worker_gate.py
+++ b/tests/async/test_sql_pool_worker_gate.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Async persistence must not create workers that fall back to one shared DB handle."""
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[2]
+pool_h = (root / "src/sql_pool.h").read_text()
+pool_c = (root / "src/sql_pool.c").read_text()
+utility = (root / "src/utility.c").read_text()
+locker = (root / "src/locker_async.c").read_text()
+
+assert "int sql_pool_is_active(void)" in pool_h
+assert "active = pool != NULL" in pool_c
+assert "if (!sql_pool_is_active())" in utility
+assert utility.count("pool_unavailable") >= 2
+assert "worker_unavailable_flat_fallback" in utility
+assert "if (!sql_pool_is_active())" in locker
+
+print("pool availability worker-gating checks passed")


### PR DESCRIPTION
## Summary

This PR fixes confirmed crash and durability issues found during an evidence-backed audit of the current `master` tip.

- initialize and safely traverse the deferred event suffix
- refuse terminal locker extraction unless a durable save succeeds
- complete persistence queue writes by stable slot generation rather than payload equality
- frame scalar fallback records for unambiguous replay
- drain retained fallback records in bounded, join-gated batches
- preserve locker room iteration while occupants are removed
- stop migrations immediately after a failed step and report the correct step count
- share latency tracing state across translation units
- prevent item/scalar/locker async workers from sharing the legacy singleton SQL handle when the connection pool is unavailable
- retain item events through the durable flat-log fallback when their worker cannot run

## Verification

- clean `src/` rebuild: passed and linked `dms_new`
- all changed source-contract tests: passed
- locker async pipeline contract: passed
- complete lightweight Python contract sweep: 115/118 passed
  - the same three failures reproduce unchanged on the base commit (`test_actwiz_save_logging.py`, `test_epic_save_guards.py`, and `test_reported_latency_contract.py`)
- compiled persistence harness: new queue-generation runtime case passed
  - the pre-existing stale-heartbeat case fails identically on both this branch and the base commit
- `bash -n migrations/run_migration.sh`: passed
- `git diff --check`: passed
- current-target trial merge: clean

## Merge gate

This is intentionally a draft. Before merging, run isolated MySQL integration and fault-injection verification for:

- migration failure stops subsequent steps and leaves an explainable partial state
- connection-pool initialization/replacement failures never share a singleton handle across workers
- scalar/item fallback records survive failure and replay exactly once
- terminal locker save failures retain the character rather than extracting it
- fallback recovery drains more than 256 retained events without loss or unbounded work

## Scope

This PR addresses the confirmed scheduler, locker, queue-identity, fallback-replay, migration-stop, latency-state, and SQL-pool worker-safety defects. Broader legacy object-lifetime redesigns are deliberately excluded.
