### PR TITLE
Hopefully fix mudbasher on iPad.

### DIFF
--- a/src/ansi.c
+++ b/src/ansi.c
@@ -88,6 +88,7 @@ static void put_term(char *&out, int attr, int lastbit)
 
 	*out++='\e';
 	*out++='[';
+	*out++='0';
 
 	if (f)
 	{


### PR DESCRIPTION
We used `\e[0m` before, I switched it to `\e[m` which is also legal according to the spec — but mudbasher's fail strongly looks like a failure to reset.  Thus, going back to `\e[0m` should fix it (untested as I got no iStuff).