### PR TITLE
Fix shadow projection never granting sneak

### DIFF
--- a/src/magic.c
+++ b/src/magic.c
@@ -6804,7 +6804,7 @@ void spell_shadow_projection(int level, P_char ch, char *arg, int type, P_char v
 		af.type       = SPELL_SHADOW_PROJECTION;
 		af.duration   = 1;
 		af.bitvector  = AFF_SNEAK;
-		af.bitvector  = AFF_HIDE;
+		af.bitvector |= AFF_HIDE;
 		af.bitvector2 = AFF2_PASSDOOR;
 		affect_to_char(ch, &af);
 


### PR DESCRIPTION
`spell_shadow_projection()` (src/magic.c:6801-6813) builds its affect with two back-to-back assignments to the same field:

```c
af.bitvector  = AFF_SNEAK;
af.bitvector  = AFF_HIDE;
af.bitvector2 = AFF2_PASSDOOR;
```

The second assignment overwrites the first, so the spell has never actually granted `AFF_SNEAK` — a shadow projection walks hidden and passes doors, but every step still prints movement messages because sneak is missing. The paired `bitvector2` line shows the intent: each line was meant to contribute one flag to the affect.

One-operator fix: the second assignment becomes `af.bitvector |= AFF_HIDE;`, so the affect carries `AFF_SNEAK | AFF_HIDE` (both flags live in the same field: `AFF_SNEAK` = BIT_20, `AFF_HIDE` = BIT_21, defines.h:661-662).

Compile-proof (WSL Ubuntu, targeted make):

```
g++ -g -std=c++20 -D_FORTIFY_SOURCE=0 -Wno-write-strings -DTEST_MUD -D__NO_TESTS__ -DCHAOS_MUD=1 -I. -I../tests/async -I/usr/include/libxml2 -I/usr/include/mysql -I./ships -ggdb3 -MMD -MP -c magic.c -o ../obj/magic.o
exit 0  (no new diagnostics; only the pre-existing snprintf-truncation notes in spell_identify/spell_lore/do_soulbind)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)