### PR TITLE
Fix unwinnable lock on the ghore vault trapdoor

### DIFF
--- a/areas/wld/ghore.wld
+++ b/areas/wld/ghore.wld
@@ -3543,7 +3543,7 @@ D5
 A large iron trapdoor.
 ~
 trapdoor~
-6 11693 11693
+6 -1 11693
 S
 #11691
 &+WAn Unused Room~
@@ -3589,7 +3589,7 @@ D4
 A trapdoor.
 ~
 trapdoor~
-2 11693 11690
+2 -1 11690
 S
 #11694
 &+YA Guest Bedroom~

--- a/areas/zon/ghore.zon
+++ b/areas/zon/ghore.zon
@@ -269,13 +269,13 @@ D 0 11691 2 1 100 0 0 0
 *     south exit from "An Unused Room" to
 *     "A Dim Hallway" - closed
 *
-D 0 11690 5 2 100 0 0 0
+D 0 11690 5 1 100 0 0 0
 *     down exit from "A Dim Hallway" to
-*     "The Vault of the Troll Chieftain" - closed/locked
+*     "The Vault of the Troll Chieftain" - closed
 *
-D 0 11693 4 2 100 0 0 0
+D 0 11693 4 1 100 0 0 0
 *     up exit from "The Vault of the Troll Chieftain" to
-*     "A Dim Hallway" - closed/locked
+*     "A Dim Hallway" - closed
 *
 D 0 11695 0 1 100 0 0 0
 *     north exit from "The Castle Dungeon" to


### PR DESCRIPTION
The iron trapdoor between **A Dim Hallway** (#11690) and **The Vault of the Troll Chieftain** (#11693) is locked behind a key that cannot exist.

**The defect.** Both sides of the trapdoor name object 11693 as their key — the destination *room* vnum, copied into the key field:

```
#11690 D5:  6 11693 11693     (ghore.wld:3546)
#11693 D4:  2 11693 11690     (ghore.wld:3592)
```

No object #11693 exists anywhere in areas/obj. `has_key()` matches keys by object vnum (`obj_index[o->R_num].virtual_number == key`, actmove.c:2476), so every mortal `unlock` ends at "You do not have the proper key for that." (actmove.c:2713). Both zone resets relock the trapdoor on every repop — `D ... 5 2` and `D ... 4 2` (ghore.zon:272, :276), state 2 = `EX_CLOSED|EX_LOCKED` (db.c:3622-3626). Net result: the vault behind the chieftain's throne room can only ever be entered by pick, doorbash or passdoor; the keyed lock is decoration that can never be satisfied.

**The repair (minimal).**
- ghore.wld: key field → `-1` on both exit lines. `-1` is `do_unlock`'s own no-keyhole convention (actmove.c:2706).
- ghore.zon: both D states 2 → 1, so resets close the trapdoor without locking it (db.c:3618-3621). The two adjacent `* ... - closed/locked` comments are updated to `- closed`.

Nothing else changes: the wld state field is untouched, so both sides remain `EX_ISDOOR|EX_PICKABLE` doors (db.c:1370-1377) — a closed iron trapdoor you now simply open.

**Intent-preserving alternative.** If the original intent was a *real* keyed vault, the right fix is the opposite direction: create a key object on a free ghore vnum (11608 and 11609 are free — obj vnums jump 11607 → 11610) and G-reset it onto Chief Kerzt Bloodeye (#11528, M-reset into the throne room #11685 at ghore.zon:773), keeping the D states at 2. That turns the chieftain into the vault's keyholder, which fits the zone's fiction nicely. This PR deliberately implements only the minimal repair — if you'd rather have the keyed version, say the word and I'll rework it that way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)