### PR TITLE
studioproc: rset/radd — remote counter writes for cross-room switch combinations

### DIFF
--- a/src/studioproc.c
+++ b/src/studioproc.c
@@ -85,6 +85,23 @@
    *   unaffect <spell|tag> [on self|actor]
    *   do [self|actor] <command line>
    *   set <counter> <n>     add <counter> <n>
+   *   rset <vnum> <counter> <n>    radd <vnum> <counter> <n>
+   *          -- set / add, but on the FIRST LIVE INSTANCE of mob
+   *             prototype <vnum> (or, when <vnum> names an object, the
+   *             first object instance) instead of on self.  Counter
+   *             names intern in the same global table, so the <counter>
+   *             a lever writes and the 'if counter <counter>' the
+   *             holder tests resolve to the same slot.  Writes are
+   *             remote; reads stay local by design -- 'if counter'
+   *             always reads self, so the holder's own trigger does the
+   *             deciding.  A moment with no live instance is a silent
+   *             no-op: the lever stays harmless while its holder awaits
+   *             a repop, and a repop starts the combination over clean
+   *             (counters are per-instance and die with the instance).
+   *             This is the primitive behind cross-room switch
+   *             combinations: each lever room writes one counter on a
+   *             shared holder, and the holder's own PULSE trigger fires
+   *             the outcome once all of them are in place.
    *   oneof <n>             -- the next n actions become a pool; one runs
    *   exit <roomvnum> <dir> [to <roomvnum>|none] [state open|closed|locked|secret]
    *   block                 -- swallow the command that triggered this
@@ -135,6 +152,8 @@ extern P_room               world;
 extern int                  top_of_world;
 extern P_index              mob_index;
 extern P_index              obj_index;
+extern P_char               character_list;   /* db.c:91       */
+extern P_obj                object_list;      /* db.c:90       */
 extern const char          *spells[];
 extern Skill                skills[];
 extern struct command_info  cmd_info[MAX_CMD_LIST];
@@ -180,7 +199,8 @@ struct sp_action
 	char *text2;                /* attack: miss message                */
 	char *text3;                /* attack: room message                */
 	int   num;                  /* vnum / spell / heal / counter value */
-	int   num2;                 /* exit: destination vnum, -1 = leave  */
+	int   num2;                 /* exit: dest vnum, -1 = leave;
+	                               rset/radd: the target vnum          */
 	int   dnum, dsize, dbonus;  /* NdS+B                               */
 	int   who;                  /* SP_WHO_xxx                          */
 	int   scope;                /* SP_SCOPE_xxx                        */
@@ -191,7 +211,8 @@ struct sp_action
 	int   slot;                 /* counter slot / exit direction       */
 	int   count;                /* oneof: pool size                    */
 	int   dur;                  /* affect duration, ticks              */
-	int   state;                /* exit state                          */
+	int   state;                /* exit state; rset/radd: target kind
+	                               (SP_T_MOB / SP_T_OBJ, parse-fixed)  */
 	int   apply;                /* affect: APPLY_xxx, 0 = APPLY_NONE   */
 	int   amod;                 /* affect: the modifier for that apply */
 	int   affword;              /* affect: AFF word 1..5, 0 = no bit   */
@@ -380,6 +401,38 @@ static void sp_obj_set(P_obj obj, int type, int slot, int value)
 	ed->next            = obj->ex_description;
 	obj->ex_description = ed;
 	obj->str_mask |= STRUNG_EDESC;
+}
+
+/* ------------------------------------------------------------------ */
+/* remote instances                                                   */
+/*                                                                    */
+/* rset / radd write a counter on ANOTHER prototype's first live      */
+/* instance, through the same sp_char_set / sp_obj_set machinery      */
+/* above.  "First" is character_list / object_list order (newest      */
+/* first), which is unambiguous in the intended use: a reset-placed   */
+/* holder that exists once.  No live instance = the caller no-ops     */
+/* silently, by design -- a lever must stay harmless, not log-spam,   */
+/* while its holder is dead or waiting on a repop.                    */
+/* ------------------------------------------------------------------ */
+
+static P_char sp_mob_instance(int vnum)
+{
+	P_char k;
+
+	for (k = character_list; k; k = k->next)
+		if (IS_NPC(k) && IS_ALIVE(k) && GET_VNUM(k) == vnum)
+			return k;
+	return NULL;
+}
+
+static P_obj sp_obj_instance(int vnum)
+{
+	P_obj o;
+
+	for (o = object_list; o; o = o->next)
+		if (o->R_num >= 0 && obj_index[o->R_num].virtual_number == vnum)
+			return o;
+	return NULL;
 }
 
 /* ------------------------------------------------------------------ */
@@ -1148,6 +1201,31 @@ static int sp_execute(struct sp_trig *t, struct sp_ctx *cx)
 
 			case SP_A_ADD:
 				sp_state_set(cx, SP_TAG_COUNTER, a->slot, sp_state_get(cx, SP_TAG_COUNTER, a->slot) + a->num);
+				break;
+
+			case SP_A_RSET:
+			case SP_A_RADD:
+				/* Remote counter write -- see the header comment.  The
+				   target KIND was fixed at parse time (a->state), so a
+				   vnum that names both a mob and an object prototype
+				   never flip-flops between the two at runtime.  No
+				   live instance = silent no-op, by design: the lever
+				   stays harmless while its holder awaits a repop, and
+				   the repop wipes the counters (they are per-instance),
+				   starting the combination over clean.  */
+				if (a->state == SP_T_MOB)
+				{
+					if ((m = sp_mob_instance(a->num2)) != NULL)
+					{
+						n = (a->op == SP_A_RADD) ? sp_char_get(m, SP_TAG_COUNTER, a->slot) + a->num : a->num;
+						sp_char_set(m, SP_TAG_COUNTER, a->slot, n);
+					}
+				}
+				else if ((o = sp_obj_instance(a->num2)) != NULL)
+				{
+					n = (a->op == SP_A_RADD) ? sp_obj_get(o, SP_TAG_COUNTER, a->slot) + a->num : a->num;
+					sp_obj_set(o, SP_TAG_COUNTER, a->slot, n);
+				}
 				break;
 
 			case SP_A_EXIT:
@@ -2772,6 +2850,39 @@ static int sp_parse_action(int targ, int vnum, struct sp_trig *t, char *line)
 		   "to" or "the" would otherwise vanish and the NEXT token would be
 		   interned as the counter name.  See the comment on sp_word(). */
 		a->op   = !strcmp(word, "set") ? SP_A_SET : SP_A_ADD;
+		p       = sp_word(p, name, sizeof(name));
+		a->slot = sp_intern_counter(name);
+		if (a->slot < 0)
+		{
+			sp_err(vnum, "counter name table full or empty name", line);
+			return FALSE;
+		}
+		sp_word(p, word, sizeof(word));
+		a->num = atoi(word);
+	}
+	else if (!strcmp(word, "rset") || !strcmp(word, "radd"))
+	{
+		/* rset|radd <vnum> <counter> <n> -- the remote forms.  A
+		   DISTINCT keyword, deliberately not an optional third
+		   argument on set/add: a counter is allowed to be named
+		   "300", and set/add ignore trailing junk after the value,
+		   so a line like "set 300 5 note" already parses today as
+		   counter "300" = 5.  An argument-count overload would
+		   silently re-read files like that; a new keyword leaves the
+		   old grammar byte-for-byte alone. */
+		a->op = !strcmp(word, "rset") ? SP_A_RSET : SP_A_RADD;
+		p     = sp_word(p, word, sizeof(word));
+		n     = atoi(word);
+		if (n > 0 && real_mobile(n) >= 0)
+			a->state = SP_T_MOB;          /* a vnum that names both: mob wins */
+		else if (n > 0 && real_object(n) >= 0)
+			a->state = SP_T_OBJ;
+		else
+		{
+			sp_err(vnum, "rset/radd: no such mob or obj vnum", line);
+			return FALSE;
+		}
+		a->num2 = n;
 		p       = sp_word(p, name, sizeof(name));
 		a->slot = sp_intern_counter(name);
 		if (a->slot < 0)

--- a/src/studioproc.h
+++ b/src/studioproc.h
@@ -79,6 +79,8 @@
 #define SP_A_ONEOF    19   /* pick 1 of the next <n> actions           */
 #define SP_A_EXIT     20   /* retarget / restate an exit               */
 #define SP_A_BLOCK    21   /* swallow the triggering command           */
+#define SP_A_RSET     22   /* remote: counter = n on another instance  */
+#define SP_A_RADD     23   /* remote: counter += n on another instance */
 
 /* ---- conditions --------------------------------------------------- */
 #define SP_C_CARRYING  0


### PR DESCRIPTION
Adds a REMOTE-COUNTER action pair to the studioproc grammar (the #152-156 family):

```
rset <vnum> <counter> <n>
radd <vnum> <counter> <n>
```

`set` / `add`, but on the **first live instance of mob prototype `<vnum>`** (or, when the vnum names an object, the first object instance) instead of on self.

## Why

ITEM_SWITCH is strictly one switch : one EX_BLOCKED exit, and studioproc counters are per-instance on *self* (src/studioproc.c:334-351 for mobs via AFFTYPE_STORE affects, :373-404 for objects via `_sp_*` extra descriptions, a flat array for rooms) — so today no data-driven mechanism can express "throw the lever in room A **and** the lever in room B to open the door in room C": state written by a trigger in one room is unreadable from a trigger anywhere else. The remote write closes exactly that gap: each lever room writes one counter on a shared HOLDER mob/object, and the holder's own PULSE trigger tests its own counters and fires the outcome (an `exit ... state open`, an `mload`, an `oload`, ...). This is the mechanism a builder (Raniskog) is currently asking for — a multi-switch combination puzzle — which the old DE toolchain also could not author natively.

## Grammar: a distinct keyword, not a `set` overload

`set`'s v1 grammar cannot grow an optional leading vnum without re-reading existing files:

- a counter is *allowed* to be named `300` — `sp_intern_counter` (src/studioproc.c:300) accepts any non-empty word;
- `set`/`add` ignore trailing junk after the value (src/studioproc.c:2847-2862 reads exactly one name and one value and never looks at the rest), so `set 300 5 note` is an accepted line today meaning counter "300" = 5.

An argument-count overload would silently turn lines like that into remote writes. `rset`/`radd` therefore parse as new top-level keywords (src/studioproc.c:2863-2895); the `set`/`add` branch is untouched, byte-for-byte identical behaviour for every existing record.

## Semantics

- **Parse time** (src/studioproc.c:2874-2884): the target vnum must resolve via `real_mobile()` — failing that `real_object()` — exactly like `mload`/`oload` (:2646/:2655) and the record-header target check (:3166/:3168); otherwise `sp_err` + record skip, the file's standing error contract. The target KIND is fixed at parse time, so a vnum that names both a mob and an object prototype never flip-flops at runtime (mob wins, matching the parse order). The counter name interns in the same global table `set` and `if counter` use (:300), so the slot a lever writes is the slot the holder's `if counter` reads.
- **Run time** (src/studioproc.c:1206-1229): find the first live instance — a `character_list` walk gated `IS_NPC && IS_ALIVE` *before* `GET_VNUM` (:423; the macro panics on PCs, utils.h:274 — same guard order as the existing `mobs` condition, :757/:764), or an `object_list` walk on `obj_index[R_num].virtual_number` (:433, the `sp_has_obj` test at :662). The write goes through the existing `sp_char_set` / `sp_obj_set` store machinery — no new state mechanism, no new lifetime to manage.
- **No live instance = silent no-op**, documented in the header comment: a lever must stay harmless, not log-spam, while its holder is dead or waiting on a repop — and the repop wipes the counters (they are per-instance, they die with the instance), which starts the combination over clean. For a puzzle that is the correct reset behaviour, for free.
- **Reads stay local, deliberately.** There is no remote form of `if counter`: a trigger always reads its *own* target's counters, so the holder's own trigger does the deciding. One writer per lever, one reader on the holder keeps the data flow auditable from the .trg file alone.

## Scope

Two action ids appended after `SP_A_BLOCK` (src/studioproc.h:82-83, the same append-only discipline the event list documents), two `extern`s for the engine's instance lists (db.c:90-91), two small locator helpers (src/studioproc.c:418-437), one executor case pair, one parse branch. No existing branch of the parser or the executor is modified.

Related: #168 (the pending `do` gate / `goto` fixes) touches this file at sp_do_command and SP_A_GOTO; this PR's hunks are disjoint from both of those, so the two merge cleanly in either order.

## Compile-proof (WSL Ubuntu, the project's own make rule, run at base d93dfd5cf and at this commit)

```
g++ -g -std=c++20 -D_FORTIFY_SOURCE=0 -Wno-write-strings -DTEST_MUD -D__NO_TESTS__ -DCHAOS_MUD=1 -I. -I../tests/async -I/usr/include/libxml2 -I/usr/include/mysql -I./ships -ggdb3 -MMD -MP -c studioproc.c -o ../obj/studioproc.o
exit 0 — no diagnostics
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
